### PR TITLE
Add feature CRUD API endpoints

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import morgan from 'morgan';
 import { RegisterRoutes } from './routes';
 import { ValidateError } from 'tsoa';
+import { DomainError } from './utils/errors';
 
 export const app = express();
 
@@ -14,6 +15,10 @@ RegisterRoutes(app);
 app.use((err: unknown, req: express.Request, res: express.Response, next: express.NextFunction) => {
   if (err instanceof ValidateError) {
     return res.status(422).json({ message: 'Validation Failed', details: err?.fields });
+  }
+  if (err instanceof DomainError) {
+    console.error(err);
+    return res.status(err.status).json({ message: err.message, details: err.details });
   }
   if (err instanceof Error) {
     console.error(err);

--- a/apps/api/src/data-source.ts
+++ b/apps/api/src/data-source.ts
@@ -1,4 +1,0 @@
-import { AppDataSource } from './data/datasource';
-
-export default AppDataSource;
-

--- a/apps/api/src/data/datasource.ts
+++ b/apps/api/src/data/datasource.ts
@@ -9,12 +9,18 @@ export const AppDataSource = new DataSource({
   username: config.db.user,
   password: config.db.password,
   database: config.db.database,
-  entities: ['dist/data/entities/*.entity.{ts,js}'],
-  migrations: ['dist/data/migrations/*.{ts,js}'],
+  entities: [
+    'src/data/entities/*.entity.ts',
+    'dist/data/entities/*.entity.js',
+  ],
+  migrations: [
+    'src/data/migrations/*.ts',
+    'dist/data/migrations/*.js',
+  ],
   synchronize: false,
   migrationsTableName: 'migration',
   migrationsTransactionMode: 'each',
   logging: 'all',
-  logger: 'advanced-console',  
+  logger: 'advanced-console',
 });
 

--- a/apps/api/src/data/entities/feature.entity.ts
+++ b/apps/api/src/data/entities/feature.entity.ts
@@ -1,4 +1,4 @@
-import { Geometry } from 'geojson';
+import type { Geometry } from 'geojson';
 import {
   Column,
   CreateDateColumn,

--- a/apps/api/src/data/repositories/feature.repository.ts
+++ b/apps/api/src/data/repositories/feature.repository.ts
@@ -1,0 +1,109 @@
+import { Geometry } from 'geojson';
+import { AppDataSource } from '../datasource';
+import { FeatureEntity, FeatureKind } from '../entities/feature.entity';
+import { BBox } from '../../utils/bbox';
+import { InternalServerError } from '../../utils/errors';
+
+export interface FeatureListParams {
+  bbox?: BBox;
+  limit: number;
+  offset: number;
+}
+
+export interface FeatureCreateParams {
+  kind: FeatureKind;
+  geometry: Geometry;
+  tags: Record<string, unknown>;
+}
+
+export type FeatureUpdateParams = FeatureCreateParams;
+
+export class FeatureRepository {
+  private readonly repository = AppDataSource.getRepository(FeatureEntity);
+
+  async findById(id: string): Promise<FeatureEntity | null> {
+    return this.repository.findOne({ where: { id } });
+  }
+
+  async list(params: FeatureListParams): Promise<{ data: FeatureEntity[]; total: number }> {
+    const queryBuilder = this.repository
+      .createQueryBuilder('feature')
+      .orderBy('feature.createdAt', 'DESC')
+      .skip(params.offset)
+      .take(params.limit);
+
+    if (params.bbox) {
+      queryBuilder.andWhere(
+        'feature.geom && ST_MakeEnvelope(:west, :south, :east, :north, 4326)',
+        {
+          west: params.bbox[0],
+          south: params.bbox[1],
+          east: params.bbox[2],
+          north: params.bbox[3],
+        }
+      );
+    }
+
+    const [data, total] = await queryBuilder.getManyAndCount();
+    return { data, total };
+  }
+
+  async create(params: FeatureCreateParams): Promise<FeatureEntity> {
+    const result = await this.repository
+      .createQueryBuilder()
+      .insert()
+      .values({
+        kind: params.kind,
+        tags: () => ':tags::jsonb',
+        geom: () => 'ST_SetSRID(ST_GeomFromGeoJSON(:geometry)::geometry, 4326)',
+      })
+      .setParameters({
+        geometry: JSON.stringify(params.geometry),
+        tags: JSON.stringify(params.tags ?? {}),
+      })
+      .returning('*')
+      .execute();
+
+    const inserted = result.identifiers[0] as { id?: string } | undefined;
+    if (!inserted?.id) {
+      throw new InternalServerError('Feature could not be persisted');
+    }
+
+    const entity = await this.findById(inserted.id);
+    if (!entity) {
+      throw new InternalServerError('Feature could not be loaded after creation');
+    }
+
+    return entity;
+  }
+
+  async update(id: string, params: FeatureUpdateParams): Promise<FeatureEntity | null> {
+    const result = await this.repository
+      .createQueryBuilder()
+      .update()
+      .set({
+        kind: params.kind,
+        tags: () => ':tags::jsonb',
+        geom: () => 'ST_SetSRID(ST_GeomFromGeoJSON(:geometry)::geometry, 4326)',
+      })
+      .where('id = :id', { id })
+      .setParameters({
+        geometry: JSON.stringify(params.geometry),
+        tags: JSON.stringify(params.tags ?? {}),
+      })
+      .returning('*')
+      .execute();
+
+    const updatedRow = result.raw[0] as { id?: string } | undefined;
+    if (!updatedRow?.id) {
+      return null;
+    }
+
+    return this.findById(updatedRow.id);
+  }
+
+  async delete(id: string): Promise<boolean> {
+    const result = await this.repository.delete({ id });
+    return Boolean(result.affected && result.affected > 0);
+  }
+}

--- a/apps/api/src/resources/feature/feature.controller.ts
+++ b/apps/api/src/resources/feature/feature.controller.ts
@@ -1,0 +1,145 @@
+import { Body, Controller, Delete, Get, Path, Post, Put, Query, Response, Route, SuccessResponse, Tags, Example } from 'tsoa';
+import { parseBBox } from '../../utils/bbox';
+import { FeatureService } from './feature.service';
+import {
+  CreateFeatureRequest,
+  FeatureCollectionResponse,
+  FeatureListQuery,
+  FeatureResponse,
+  UpdateFeatureRequest,
+} from './feature.resource';
+import { DomainError, NotFoundError, ValidationError } from '../../utils/errors';
+
+@Route('features')
+@Tags('features')
+@Response<DomainError>(500, 'Server error')
+@Response<ValidationError>(422, 'Validation error')
+@Response<NotFoundError>(404, 'Feature not found')
+export class FeatureController extends Controller {
+  private readonly service = new FeatureService();
+
+  /** List features optionally filtered by a bounding box. */
+  @Get()
+  @Example<FeatureCollectionResponse>({
+    type: 'FeatureCollection',
+    bbox: [-0.1, -0.1, 0.1, 0.1],
+    features: [
+      {
+        type: 'Feature',
+        id: '8d91a8c9-9a73-4f25-bfe1-2eac898d0c04',
+        geometry: {
+          type: 'Point',
+          coordinates: [0, 0],
+        },
+        properties: {
+          kind: 'point',
+          tags: { name: 'Null Island' },
+          createdAt: '2024-01-01T00:00:00.000Z',
+          updatedAt: '2024-01-01T00:00:00.000Z',
+        },
+      },
+    ],
+    pagination: {
+      total: 1,
+      limit: 50,
+      offset: 0,
+    },
+  })
+  public async listFeatures(
+    @Query() bbox?: string,
+    @Query() limit?: number,
+    @Query() offset?: number
+  ): Promise<FeatureCollectionResponse> {
+    const query: FeatureListQuery = {
+      bbox: bbox ? parseBBox(bbox) : undefined,
+      limit,
+      offset,
+    };
+
+    return this.service.listFeatures(query);
+  }
+
+  /** Retrieve a single feature by id. */
+  @Get('{featureId}')
+  @Example<FeatureResponse>({
+    type: 'Feature',
+    id: '8d91a8c9-9a73-4f25-bfe1-2eac898d0c04',
+    geometry: {
+      type: 'Point',
+      coordinates: [0, 0],
+    },
+    properties: {
+      kind: 'point',
+      tags: { name: 'Null Island' },
+      createdAt: '2024-01-01T00:00:00.000Z',
+      updatedAt: '2024-01-01T00:00:00.000Z',
+    },
+  })
+  public async getFeature(@Path() featureId: string): Promise<FeatureResponse> {
+    return this.service.getFeature(featureId);
+  }
+
+  /** Create a new feature. */
+  @Post()
+  @SuccessResponse(201, 'Created')
+  @Example<FeatureResponse>({
+    type: 'Feature',
+    id: '11111111-1111-1111-1111-111111111111',
+    geometry: {
+      type: 'LineString',
+      coordinates: [
+        [-74.00597, 40.71427],
+        [-73.98513, 40.7589],
+      ],
+    },
+    properties: {
+      kind: 'line',
+      tags: { name: 'Broadway' },
+      createdAt: '2024-01-01T00:00:00.000Z',
+      updatedAt: '2024-01-01T00:00:00.000Z',
+    },
+  })
+  public async createFeature(@Body() body: CreateFeatureRequest): Promise<FeatureResponse> {
+    this.setStatus(201);
+    return this.service.createFeature(body);
+  }
+
+  /** Replace an existing feature. */
+  @Put('{featureId}')
+  @Example<FeatureResponse>({
+    type: 'Feature',
+    id: '22222222-2222-2222-2222-222222222222',
+    geometry: {
+      type: 'Polygon',
+      coordinates: [
+        [
+          [-122.431297, 37.773972],
+          [-122.431297, 37.783972],
+          [-122.421297, 37.783972],
+          [-122.421297, 37.773972],
+          [-122.431297, 37.773972],
+        ],
+      ],
+    },
+    properties: {
+      kind: 'polygon',
+      tags: { name: 'Sample Block' },
+      createdAt: '2024-01-01T00:00:00.000Z',
+      updatedAt: '2024-01-01T00:00:00.000Z',
+    },
+  })
+  public async updateFeature(
+    @Path() featureId: string,
+    @Body() body: UpdateFeatureRequest
+  ): Promise<FeatureResponse> {
+    return this.service.updateFeature(featureId, body);
+  }
+
+  /** Delete a feature. */
+  @Delete('{featureId}')
+  @SuccessResponse(204, 'No Content')
+  public async deleteFeature(@Path() featureId: string): Promise<void> {
+    await this.service.deleteFeature(featureId);
+    this.setStatus(204);
+  }
+}

--- a/apps/api/src/resources/feature/feature.resource.ts
+++ b/apps/api/src/resources/feature/feature.resource.ts
@@ -1,0 +1,54 @@
+import { FeatureKind } from '../../data/entities/feature.entity';
+import { BBox } from '../../utils/bbox';
+
+export type GeometryType =
+  | 'Point'
+  | 'MultiPoint'
+  | 'LineString'
+  | 'MultiLineString'
+  | 'Polygon'
+  | 'MultiPolygon';
+
+export interface GeometryDto {
+  type: GeometryType;
+  coordinates: unknown;
+}
+
+export interface FeatureProperties {
+  kind: FeatureKind;
+  tags: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface FeatureResponse {
+  type: 'Feature';
+  id: string;
+  geometry: GeometryDto;
+  properties: FeatureProperties;
+}
+
+export interface FeatureCollectionResponse {
+  type: 'FeatureCollection';
+  features: FeatureResponse[];
+  bbox?: number[];
+  pagination: {
+    total: number;
+    limit: number;
+    offset: number;
+  };
+}
+
+export interface CreateFeatureRequest {
+  kind: FeatureKind;
+  geometry: GeometryDto;
+  tags?: Record<string, unknown>;
+}
+
+export type UpdateFeatureRequest = CreateFeatureRequest;
+
+export interface FeatureListQuery {
+  bbox?: BBox;
+  limit?: number;
+  offset?: number;
+}

--- a/apps/api/src/resources/feature/feature.service.ts
+++ b/apps/api/src/resources/feature/feature.service.ts
@@ -1,0 +1,213 @@
+import { Geometry } from 'geojson';
+import { FeatureEntity, FeatureKind } from '../../data/entities/feature.entity';
+import { FeatureRepository } from '../../data/repositories/feature.repository';
+import { isValidGeometry } from '../../utils/geometry';
+import { InternalServerError, NotFoundError, ValidationError } from '../../utils/errors';
+import {
+  CreateFeatureRequest,
+  FeatureCollectionResponse,
+  FeatureListQuery,
+  FeatureProperties,
+  FeatureResponse,
+  GeometryDto,
+  GeometryType,
+  UpdateFeatureRequest,
+} from './feature.resource';
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 100;
+const DEFAULT_OFFSET = 0;
+const GEOMETRY_BY_KIND: Record<FeatureKind, GeometryType[]> = {
+  point: ['Point', 'MultiPoint'],
+  line: ['LineString', 'MultiLineString'],
+  polygon: ['Polygon', 'MultiPolygon'],
+  road: ['LineString', 'MultiLineString'],
+};
+const SUPPORTED_GEOMETRY_TYPES = new Set<GeometryType>(
+  Object.values(GEOMETRY_BY_KIND).flat() as GeometryType[]
+);
+
+export class FeatureService {
+  constructor(private readonly repository = new FeatureRepository()) {}
+
+  async listFeatures(query: FeatureListQuery): Promise<FeatureCollectionResponse> {
+    const limit = this.validateLimit(query.limit);
+    const offset = this.validateOffset(query.offset);
+    const bbox = query.bbox;
+
+    const { data, total } = await this.repository.list({ bbox, limit, offset });
+    const features = data.map((entity) => this.toFeatureResponse(entity));
+
+    const collection: FeatureCollectionResponse = {
+      type: 'FeatureCollection',
+      features,
+      pagination: {
+        total,
+        limit,
+        offset,
+      },
+    };
+
+    if (bbox) {
+      collection.bbox = bbox;
+    }
+
+    return collection;
+  }
+
+  async getFeature(id: string): Promise<FeatureResponse> {
+    const entity = await this.repository.findById(id);
+    if (!entity) {
+      throw new NotFoundError('Feature', id);
+    }
+    return this.toFeatureResponse(entity);
+  }
+
+  async createFeature(payload: CreateFeatureRequest): Promise<FeatureResponse> {
+    const tags = this.validateTags(payload.tags);
+    const geometry = this.normalizeGeometry(payload.geometry, payload.kind);
+    const entity = await this.repository.create({
+      kind: payload.kind,
+      geometry,
+      tags,
+    });
+    return this.toFeatureResponse(entity);
+  }
+
+  async updateFeature(id: string, payload: UpdateFeatureRequest): Promise<FeatureResponse> {
+    const tags = this.validateTags(payload.tags);
+    const geometry = this.normalizeGeometry(payload.geometry, payload.kind);
+    const entity = await this.repository.update(id, {
+      kind: payload.kind,
+      geometry,
+      tags,
+    });
+    if (!entity) {
+      throw new NotFoundError('Feature', id);
+    }
+    return this.toFeatureResponse(entity);
+  }
+
+  async deleteFeature(id: string): Promise<void> {
+    const deleted = await this.repository.delete(id);
+    if (!deleted) {
+      throw new NotFoundError('Feature', id);
+    }
+  }
+
+  private validateLimit(limit?: number): number {
+    if (limit === undefined) {
+      return DEFAULT_LIMIT;
+    }
+    if (!Number.isInteger(limit)) {
+      throw new ValidationError('limit must be an integer', { limit });
+    }
+    if (limit <= 0) {
+      throw new ValidationError('limit must be greater than zero', { limit });
+    }
+    if (limit > MAX_LIMIT) {
+      throw new ValidationError(`limit must be less than or equal to ${MAX_LIMIT}`, { limit });
+    }
+    return limit;
+  }
+
+  private validateOffset(offset?: number): number {
+    if (offset === undefined) {
+      return DEFAULT_OFFSET;
+    }
+    if (!Number.isInteger(offset)) {
+      throw new ValidationError('offset must be an integer', { offset });
+    }
+    if (offset < 0) {
+      throw new ValidationError('offset must be greater than or equal to zero', { offset });
+    }
+    return offset;
+  }
+
+  private validateTags(tags?: Record<string, unknown>): Record<string, unknown> {
+    if (tags === undefined) {
+      return {};
+    }
+    if (tags === null || typeof tags !== 'object' || Array.isArray(tags)) {
+      throw new ValidationError('tags must be an object', { tags });
+    }
+    return { ...tags };
+  }
+
+  private normalizeGeometry(input: GeometryDto, kind: FeatureKind): Geometry {
+    const candidate = input as unknown;
+    if (!isValidGeometry(candidate)) {
+      throw new ValidationError('geometry must be a valid GeoJSON geometry object');
+    }
+
+    const geometry = candidate as Geometry;
+    if (!this.isSupportedGeometryType(geometry.type)) {
+      throw new ValidationError('geometry type is not supported', { geometryType: geometry.type });
+    }
+
+    const allowed = GEOMETRY_BY_KIND[kind];
+    if (!allowed.includes(geometry.type as GeometryType)) {
+      throw new ValidationError('geometry type is incompatible with feature kind', {
+        kind,
+        geometryType: geometry.type,
+      });
+    }
+
+    return geometry;
+  }
+
+  private toFeatureResponse(entity: FeatureEntity): FeatureResponse {
+    const geometry = this.parseGeometry(entity.geom);
+    const geometryDto = this.toGeometryDto(geometry);
+    const properties: FeatureProperties = {
+      kind: entity.kind,
+      tags: this.cloneTags(entity.tags),
+      createdAt: entity.createdAt.toISOString(),
+      updatedAt: entity.updatedAt.toISOString(),
+    };
+
+    return {
+      type: 'Feature',
+      id: entity.id,
+      geometry: geometryDto,
+      properties,
+    };
+  }
+
+  private parseGeometry(geometry: FeatureEntity['geom']): Geometry {
+    if (typeof geometry === 'string') {
+      try {
+        return JSON.parse(geometry);
+      } catch (error) {
+        throw new InternalServerError('Stored geometry is malformed', { error });
+      }
+    }
+
+    if (geometry && typeof geometry === 'object') {
+      return geometry as Geometry;
+    }
+
+    throw new InternalServerError('Stored geometry is missing or invalid');
+  }
+
+  private toGeometryDto(geometry: Geometry): GeometryDto {
+    if (!this.isSupportedGeometryType(geometry.type)) {
+      throw new InternalServerError('Stored geometry type is unsupported', { geometryType: geometry.type });
+    }
+    return geometry as unknown as GeometryDto;
+  }
+
+  private cloneTags(tags: FeatureEntity['tags']): Record<string, unknown> {
+    if (tags === null || tags === undefined) {
+      return {};
+    }
+    if (typeof tags !== 'object' || Array.isArray(tags)) {
+      throw new InternalServerError('Stored tags are invalid');
+    }
+    return { ...tags };
+  }
+
+  private isSupportedGeometryType(type: Geometry['type']): type is GeometryType {
+    return SUPPORTED_GEOMETRY_TYPES.has(type as GeometryType);
+  }
+}

--- a/apps/api/src/routes.ts
+++ b/apps/api/src/routes.ts
@@ -5,6 +5,8 @@ import type { TsoaRoute } from '@tsoa/runtime';
 import {  fetchMiddlewares, ExpressTemplateService } from '@tsoa/runtime';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { StatusController } from './resources/status/status.controller';
+// WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+import { FeatureController } from './resources/feature/feature.controller';
 import type { Request as ExRequest, Response as ExResponse, RequestHandler, Router } from 'express';
 
 
@@ -12,6 +14,42 @@ import type { Request as ExRequest, Response as ExResponse, RequestHandler, Rout
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 
 const models: TsoaRoute.Models = {
+    "DomainError": {
+        "dataType": "refObject",
+        "properties": {
+            "name": {"dataType":"string","required":true},
+            "message": {"dataType":"string","required":true},
+            "stack": {"dataType":"string"},
+            "status": {"dataType":"double","required":true},
+            "details": {"dataType":"any"},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "ValidationError": {
+        "dataType": "refObject",
+        "properties": {
+            "name": {"dataType":"string","required":true},
+            "message": {"dataType":"string","required":true},
+            "stack": {"dataType":"string"},
+            "status": {"dataType":"double","required":true},
+            "details": {"dataType":"any"},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "NotFoundError": {
+        "dataType": "refObject",
+        "properties": {
+            "name": {"dataType":"string","required":true},
+            "message": {"dataType":"string","required":true},
+            "stack": {"dataType":"string"},
+            "status": {"dataType":"double","required":true},
+            "details": {"dataType":"any"},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "HealthResponse": {
         "dataType": "refObject",
         "properties": {
@@ -47,6 +85,78 @@ const models: TsoaRoute.Models = {
             "memory": {"ref":"process.NodeJS.MemoryUsage","required":true},
         },
         "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "GeometryType": {
+        "dataType": "refAlias",
+        "type": {"dataType":"union","subSchemas":[{"dataType":"enum","enums":["Point"]},{"dataType":"enum","enums":["MultiPoint"]},{"dataType":"enum","enums":["LineString"]},{"dataType":"enum","enums":["MultiLineString"]},{"dataType":"enum","enums":["Polygon"]},{"dataType":"enum","enums":["MultiPolygon"]}],"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "GeometryDto": {
+        "dataType": "refObject",
+        "properties": {
+            "type": {"ref":"GeometryType","required":true},
+            "coordinates": {"dataType":"any","required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "FeatureKind": {
+        "dataType": "refAlias",
+        "type": {"dataType":"union","subSchemas":[{"dataType":"enum","enums":["point"]},{"dataType":"enum","enums":["line"]},{"dataType":"enum","enums":["polygon"]},{"dataType":"enum","enums":["road"]}],"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "Record_string.unknown_": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{},"additionalProperties":{"dataType":"any"},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "FeatureProperties": {
+        "dataType": "refObject",
+        "properties": {
+            "kind": {"ref":"FeatureKind","required":true},
+            "tags": {"ref":"Record_string.unknown_","required":true},
+            "createdAt": {"dataType":"string","required":true},
+            "updatedAt": {"dataType":"string","required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "FeatureResponse": {
+        "dataType": "refObject",
+        "properties": {
+            "type": {"dataType":"enum","enums":["Feature"],"required":true},
+            "id": {"dataType":"string","required":true},
+            "geometry": {"ref":"GeometryDto","required":true},
+            "properties": {"ref":"FeatureProperties","required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "FeatureCollectionResponse": {
+        "dataType": "refObject",
+        "properties": {
+            "type": {"dataType":"enum","enums":["FeatureCollection"],"required":true},
+            "features": {"dataType":"array","array":{"dataType":"refObject","ref":"FeatureResponse"},"required":true},
+            "bbox": {"dataType":"array","array":{"dataType":"double"}},
+            "pagination": {"dataType":"nestedObjectLiteral","nestedProperties":{"offset":{"dataType":"double","required":true},"limit":{"dataType":"double","required":true},"total":{"dataType":"double","required":true}},"required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "CreateFeatureRequest": {
+        "dataType": "refObject",
+        "properties": {
+            "kind": {"ref":"FeatureKind","required":true},
+            "geometry": {"ref":"GeometryDto","required":true},
+            "tags": {"ref":"Record_string.unknown_"},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "UpdateFeatureRequest": {
+        "dataType": "refAlias",
+        "type": {"ref":"CreateFeatureRequest","validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 };
@@ -147,6 +257,159 @@ export function RegisterRoutes(app: Router) {
                 next,
                 validatedArgs,
                 successStatus: undefined,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsFeatureController_listFeatures: Record<string, TsoaRoute.ParameterSchema> = {
+                bbox: {"in":"query","name":"bbox","dataType":"string"},
+                limit: {"in":"query","name":"limit","dataType":"double"},
+                offset: {"in":"query","name":"offset","dataType":"double"},
+        };
+        app.get('/features',
+            ...(fetchMiddlewares<RequestHandler>(FeatureController)),
+            ...(fetchMiddlewares<RequestHandler>(FeatureController.prototype.listFeatures)),
+
+            async function FeatureController_listFeatures(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsFeatureController_listFeatures, request, response });
+
+                const controller = new FeatureController();
+
+              await templateService.apiHandler({
+                methodName: 'listFeatures',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: undefined,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsFeatureController_getFeature: Record<string, TsoaRoute.ParameterSchema> = {
+                featureId: {"in":"path","name":"featureId","required":true,"dataType":"string"},
+        };
+        app.get('/features/:featureId',
+            ...(fetchMiddlewares<RequestHandler>(FeatureController)),
+            ...(fetchMiddlewares<RequestHandler>(FeatureController.prototype.getFeature)),
+
+            async function FeatureController_getFeature(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsFeatureController_getFeature, request, response });
+
+                const controller = new FeatureController();
+
+              await templateService.apiHandler({
+                methodName: 'getFeature',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: undefined,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsFeatureController_createFeature: Record<string, TsoaRoute.ParameterSchema> = {
+                body: {"in":"body","name":"body","required":true,"ref":"CreateFeatureRequest"},
+        };
+        app.post('/features',
+            ...(fetchMiddlewares<RequestHandler>(FeatureController)),
+            ...(fetchMiddlewares<RequestHandler>(FeatureController.prototype.createFeature)),
+
+            async function FeatureController_createFeature(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsFeatureController_createFeature, request, response });
+
+                const controller = new FeatureController();
+
+              await templateService.apiHandler({
+                methodName: 'createFeature',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: 201,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsFeatureController_updateFeature: Record<string, TsoaRoute.ParameterSchema> = {
+                featureId: {"in":"path","name":"featureId","required":true,"dataType":"string"},
+                body: {"in":"body","name":"body","required":true,"ref":"UpdateFeatureRequest"},
+        };
+        app.put('/features/:featureId',
+            ...(fetchMiddlewares<RequestHandler>(FeatureController)),
+            ...(fetchMiddlewares<RequestHandler>(FeatureController.prototype.updateFeature)),
+
+            async function FeatureController_updateFeature(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsFeatureController_updateFeature, request, response });
+
+                const controller = new FeatureController();
+
+              await templateService.apiHandler({
+                methodName: 'updateFeature',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: undefined,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsFeatureController_deleteFeature: Record<string, TsoaRoute.ParameterSchema> = {
+                featureId: {"in":"path","name":"featureId","required":true,"dataType":"string"},
+        };
+        app.delete('/features/:featureId',
+            ...(fetchMiddlewares<RequestHandler>(FeatureController)),
+            ...(fetchMiddlewares<RequestHandler>(FeatureController.prototype.deleteFeature)),
+
+            async function FeatureController_deleteFeature(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsFeatureController_deleteFeature, request, response });
+
+                const controller = new FeatureController();
+
+              await templateService.apiHandler({
+                methodName: 'deleteFeature',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: 204,
               });
             } catch (err) {
                 return next(err);

--- a/apps/api/src/spec/openapi.json
+++ b/apps/api/src/spec/openapi.json
@@ -7,6 +7,81 @@
 		"requestBodies": {},
 		"responses": {},
 		"schemas": {
+			"DomainError": {
+				"properties": {
+					"name": {
+						"type": "string"
+					},
+					"message": {
+						"type": "string"
+					},
+					"stack": {
+						"type": "string"
+					},
+					"status": {
+						"type": "number",
+						"format": "double"
+					},
+					"details": {}
+				},
+				"required": [
+					"name",
+					"message",
+					"status"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"ValidationError": {
+				"properties": {
+					"name": {
+						"type": "string"
+					},
+					"message": {
+						"type": "string"
+					},
+					"stack": {
+						"type": "string"
+					},
+					"status": {
+						"type": "number",
+						"format": "double"
+					},
+					"details": {}
+				},
+				"required": [
+					"name",
+					"message",
+					"status"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"NotFoundError": {
+				"properties": {
+					"name": {
+						"type": "string"
+					},
+					"message": {
+						"type": "string"
+					},
+					"stack": {
+						"type": "string"
+					},
+					"status": {
+						"type": "number",
+						"format": "double"
+					},
+					"details": {}
+				},
+				"required": [
+					"name",
+					"message",
+					"status"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
 			"HealthResponse": {
 				"properties": {
 					"status": {
@@ -88,6 +163,173 @@
 				],
 				"type": "object",
 				"additionalProperties": false
+			},
+			"GeometryType": {
+				"type": "string",
+				"enum": [
+					"Point",
+					"MultiPoint",
+					"LineString",
+					"MultiLineString",
+					"Polygon",
+					"MultiPolygon"
+				]
+			},
+			"GeometryDto": {
+				"properties": {
+					"type": {
+						"$ref": "#/components/schemas/GeometryType"
+					},
+					"coordinates": {}
+				},
+				"required": [
+					"type",
+					"coordinates"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"FeatureKind": {
+				"type": "string",
+				"enum": [
+					"point",
+					"line",
+					"polygon",
+					"road"
+				]
+			},
+			"Record_string.unknown_": {
+				"properties": {},
+				"additionalProperties": {},
+				"type": "object",
+				"description": "Construct a type with a set of properties K of type T"
+			},
+			"FeatureProperties": {
+				"properties": {
+					"kind": {
+						"$ref": "#/components/schemas/FeatureKind"
+					},
+					"tags": {
+						"$ref": "#/components/schemas/Record_string.unknown_"
+					},
+					"createdAt": {
+						"type": "string"
+					},
+					"updatedAt": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"kind",
+					"tags",
+					"createdAt",
+					"updatedAt"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"FeatureResponse": {
+				"properties": {
+					"type": {
+						"type": "string",
+						"enum": [
+							"Feature"
+						],
+						"nullable": false
+					},
+					"id": {
+						"type": "string"
+					},
+					"geometry": {
+						"$ref": "#/components/schemas/GeometryDto"
+					},
+					"properties": {
+						"$ref": "#/components/schemas/FeatureProperties"
+					}
+				},
+				"required": [
+					"type",
+					"id",
+					"geometry",
+					"properties"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"FeatureCollectionResponse": {
+				"properties": {
+					"type": {
+						"type": "string",
+						"enum": [
+							"FeatureCollection"
+						],
+						"nullable": false
+					},
+					"features": {
+						"items": {
+							"$ref": "#/components/schemas/FeatureResponse"
+						},
+						"type": "array"
+					},
+					"bbox": {
+						"items": {
+							"type": "number",
+							"format": "double"
+						},
+						"type": "array"
+					},
+					"pagination": {
+						"properties": {
+							"offset": {
+								"type": "number",
+								"format": "double"
+							},
+							"limit": {
+								"type": "number",
+								"format": "double"
+							},
+							"total": {
+								"type": "number",
+								"format": "double"
+							}
+						},
+						"required": [
+							"offset",
+							"limit",
+							"total"
+						],
+						"type": "object"
+					}
+				},
+				"required": [
+					"type",
+					"features",
+					"pagination"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"CreateFeatureRequest": {
+				"properties": {
+					"kind": {
+						"$ref": "#/components/schemas/FeatureKind"
+					},
+					"geometry": {
+						"$ref": "#/components/schemas/GeometryDto"
+					},
+					"tags": {
+						"$ref": "#/components/schemas/Record_string.unknown_"
+					}
+				},
+				"required": [
+					"kind",
+					"geometry"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"UpdateFeatureRequest": {
+				"$ref": "#/components/schemas/CreateFeatureRequest"
 			}
 		},
 		"securitySchemes": {}
@@ -165,6 +407,466 @@
 				],
 				"security": [],
 				"parameters": []
+			}
+		},
+		"/features": {
+			"get": {
+				"operationId": "ListFeatures",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/FeatureCollectionResponse"
+								},
+								"examples": {
+									"Example 1": {
+										"value": {
+											"type": "FeatureCollection",
+											"bbox": [
+												-0.1,
+												-0.1,
+												0.1,
+												0.1
+											],
+											"features": [
+												{
+													"type": "Feature",
+													"id": "8d91a8c9-9a73-4f25-bfe1-2eac898d0c04",
+													"geometry": {
+														"type": "Point",
+														"coordinates": [
+															0,
+															0
+														]
+													},
+													"properties": {
+														"kind": "point",
+														"tags": {
+															"name": "Null Island"
+														},
+														"createdAt": "2024-01-01T00:00:00.000Z",
+														"updatedAt": "2024-01-01T00:00:00.000Z"
+													}
+												}
+											],
+											"pagination": {
+												"total": 1,
+												"limit": 50,
+												"offset": 0
+											}
+										}
+									}
+								}
+							}
+						}
+					},
+					"404": {
+						"description": "Feature not found",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/NotFoundError"
+								}
+							}
+						}
+					},
+					"422": {
+						"description": "Validation error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ValidationError"
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Server error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/DomainError"
+								}
+							}
+						}
+					}
+				},
+				"description": "List features optionally filtered by a bounding box.",
+				"tags": [
+					"features"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"in": "query",
+						"name": "bbox",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "limit",
+						"required": false,
+						"schema": {
+							"format": "double",
+							"type": "number"
+						}
+					},
+					{
+						"in": "query",
+						"name": "offset",
+						"required": false,
+						"schema": {
+							"format": "double",
+							"type": "number"
+						}
+					}
+				]
+			},
+			"post": {
+				"operationId": "CreateFeature",
+				"responses": {
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/FeatureResponse"
+								},
+								"examples": {
+									"Example 1": {
+										"value": {
+											"type": "Feature",
+											"id": "11111111-1111-1111-1111-111111111111",
+											"geometry": {
+												"type": "LineString",
+												"coordinates": [
+													[
+														-74.00597,
+														40.71427
+													],
+													[
+														-73.98513,
+														40.7589
+													]
+												]
+											},
+											"properties": {
+												"kind": "line",
+												"tags": {
+													"name": "Broadway"
+												},
+												"createdAt": "2024-01-01T00:00:00.000Z",
+												"updatedAt": "2024-01-01T00:00:00.000Z"
+											}
+										}
+									}
+								}
+							}
+						}
+					},
+					"404": {
+						"description": "Feature not found",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/NotFoundError"
+								}
+							}
+						}
+					},
+					"422": {
+						"description": "Validation error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ValidationError"
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Server error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/DomainError"
+								}
+							}
+						}
+					}
+				},
+				"description": "Create a new feature.",
+				"tags": [
+					"features"
+				],
+				"security": [],
+				"parameters": [],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/CreateFeatureRequest"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/features/{featureId}": {
+			"get": {
+				"operationId": "GetFeature",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/FeatureResponse"
+								},
+								"examples": {
+									"Example 1": {
+										"value": {
+											"type": "Feature",
+											"id": "8d91a8c9-9a73-4f25-bfe1-2eac898d0c04",
+											"geometry": {
+												"type": "Point",
+												"coordinates": [
+													0,
+													0
+												]
+											},
+											"properties": {
+												"kind": "point",
+												"tags": {
+													"name": "Null Island"
+												},
+												"createdAt": "2024-01-01T00:00:00.000Z",
+												"updatedAt": "2024-01-01T00:00:00.000Z"
+											}
+										}
+									}
+								}
+							}
+						}
+					},
+					"404": {
+						"description": "Feature not found",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/NotFoundError"
+								}
+							}
+						}
+					},
+					"422": {
+						"description": "Validation error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ValidationError"
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Server error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/DomainError"
+								}
+							}
+						}
+					}
+				},
+				"description": "Retrieve a single feature by id.",
+				"tags": [
+					"features"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "featureId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			},
+			"put": {
+				"operationId": "UpdateFeature",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/FeatureResponse"
+								},
+								"examples": {
+									"Example 1": {
+										"value": {
+											"type": "Feature",
+											"id": "22222222-2222-2222-2222-222222222222",
+											"geometry": {
+												"type": "Polygon",
+												"coordinates": [
+													[
+														[
+															-122.431297,
+															37.773972
+														],
+														[
+															-122.431297,
+															37.783972
+														],
+														[
+															-122.421297,
+															37.783972
+														],
+														[
+															-122.421297,
+															37.773972
+														],
+														[
+															-122.431297,
+															37.773972
+														]
+													]
+												]
+											},
+											"properties": {
+												"kind": "polygon",
+												"tags": {
+													"name": "Sample Block"
+												},
+												"createdAt": "2024-01-01T00:00:00.000Z",
+												"updatedAt": "2024-01-01T00:00:00.000Z"
+											}
+										}
+									}
+								}
+							}
+						}
+					},
+					"404": {
+						"description": "Feature not found",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/NotFoundError"
+								}
+							}
+						}
+					},
+					"422": {
+						"description": "Validation error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ValidationError"
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Server error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/DomainError"
+								}
+							}
+						}
+					}
+				},
+				"description": "Replace an existing feature.",
+				"tags": [
+					"features"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "featureId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/UpdateFeatureRequest"
+							}
+						}
+					}
+				}
+			},
+			"delete": {
+				"operationId": "DeleteFeature",
+				"responses": {
+					"204": {
+						"description": "No Content"
+					},
+					"404": {
+						"description": "Feature not found",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/NotFoundError"
+								}
+							}
+						}
+					},
+					"422": {
+						"description": "Validation error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ValidationError"
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Server error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/DomainError"
+								}
+							}
+						}
+					}
+				},
+				"description": "Delete a feature.",
+				"tags": [
+					"features"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "featureId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
 			}
 		}
 	},

--- a/apps/api/src/utils/bbox.ts
+++ b/apps/api/src/utils/bbox.ts
@@ -1,0 +1,26 @@
+import { ValidationError } from './errors';
+
+export type BBox = [number, number, number, number];
+
+export function parseBBox(input: string): BBox {
+  const parts = input.split(',').map((part) => part.trim());
+  if (parts.length !== 4) {
+    throw new ValidationError('bbox must contain four comma-separated numbers', { value: input });
+  }
+
+  const values = parts.map((value) => Number(value));
+  if (values.some((value) => Number.isNaN(value) || !Number.isFinite(value))) {
+    throw new ValidationError('bbox values must be valid numbers', { value: input });
+  }
+
+  const [minLon, minLat, maxLon, maxLat] = values as BBox;
+  if (minLon >= maxLon || minLat >= maxLat) {
+    throw new ValidationError('bbox coordinates must define a valid area', { value: input });
+  }
+
+  if (minLon < -180 || maxLon > 180 || minLat < -90 || maxLat > 90) {
+    throw new ValidationError('bbox coordinates must be within WGS84 bounds', { value: input });
+  }
+
+  return [minLon, minLat, maxLon, maxLat];
+}

--- a/apps/api/src/utils/errors.ts
+++ b/apps/api/src/utils/errors.ts
@@ -1,0 +1,30 @@
+export class DomainError extends Error {
+  public readonly status: number;
+  public readonly details?: unknown;
+
+  constructor(message: string, status: number, details?: unknown) {
+    super(message);
+    this.name = new.target.name;
+    this.status = status;
+    this.details = details;
+  }
+}
+
+export class ValidationError extends DomainError {
+  constructor(message: string, details?: unknown) {
+    super(message, 422, details);
+  }
+}
+
+export class NotFoundError extends DomainError {
+  constructor(resource: string, identifier?: string) {
+    const message = identifier ? `${resource} not found: ${identifier}` : `${resource} not found`;
+    super(message, 404);
+  }
+}
+
+export class InternalServerError extends DomainError {
+  constructor(message: string, details?: unknown) {
+    super(message, 500, details);
+  }
+}


### PR DESCRIPTION
## Context
- expose CRUD operations for spatial features so the frontend can browse and edit stored geometries
- align the API surface with the Phase 4 plan, including bbox filters and pagination

## Solution
- add reusable domain error classes, bbox parsing helpers, and integrate them into the Express error pipeline
- implement feature repository, service, DTOs, and a tsoa controller that validates geometry/kind combinations and maps PostGIS data to GeoJSON responses
- regenerate the OpenAPI spec and routes so the new endpoints and examples are documented

## Verification
- `pnpm -C apps/api lint`
- `pnpm -C apps/api typecheck`
- `pnpm -C apps/api build`

## Impact
- no database schema changes; relies on existing `features` table


------
https://chatgpt.com/codex/tasks/task_e_68d07d7afc2c83269c3038f830e23a2f