### PR TITLE
Implement Phase 8 UI cleanup

### DIFF
--- a/.github/instructions/react.instructions.md
+++ b/.github/instructions/react.instructions.md
@@ -34,19 +34,61 @@ These instructions guide GitHub Copilot to produce consistent, high-quality code
 src/
   main.tsx                 # createRoot + RouterProvider
   app/
-    routes/                # route modules (lazy)
-      index.tsx            # home
-      users/
-        index.tsx          # list
-        $userId.tsx        # detail
-    layouts/
-      RootLayout.tsx       # shell (nav/header/sidebar/outlet)
-  components/              # reusable PrimeReact-based components
-  hooks/                   # custom hooks
+    layouts/               # shared layouts
+      RootLayout.tsx
+  pages/                   # all route pages (each page has its own folder)
+  components/              # reusable components promoted from pages
+  hooks/                   # reusable hooks promoted from pages
   lib/                     # apiClient, query keys, utils
   styles/                  # theme overrides, global.css
-  tests/                   # unit/integration
+  tests/                   # shared utilities for testing
 ```
+
+## 📁 Pages & Component Organization
+
+- All top-level routes live in `/src/pages`.
+- Each page has its **own folder** under `/pages`.
+- **Never** put all UI/controls inline in one big page file — always break down into smaller components/hooks, even if only used in that page.
+- Each page folder acts as a **mini-module**, containing its layout, components, hooks, types, and tests.
+
+### ✅ Standard Naming Convention
+
+Inside `/src/pages/{pageName}`:
+
+- `index.tsx` → **entry point only**. Re-exports the main page component for routing. Must not contain UI logic.
+- `{pageName}.tsx` → main page component, top-level container.
+- `{pageName}-*.tsx` → supporting components (`home-grid.tsx`, `user-form.tsx`).
+- `{pageName}.hooks.ts` → custom hooks scoped to the page.
+- `{pageName}.types.ts` → shared TS types/interfaces.
+- `{pageName}.test.tsx` → tests for the main page. Supporting components may also have their own `*.test.tsx`.
+- `{pageName}.stories.tsx` → optional Storybook stories colocated with the component.
+
+### ✅ Example Structure
+
+```
+src/
+  pages/
+    home/
+      index.tsx           # re-exports HomePage
+      home.tsx            # main page component
+      home-grid.tsx       # subcomponent
+      home-panel.tsx      # subcomponent
+      home.hooks.ts       # page-specific hooks
+      home.types.ts       # page-specific types
+      home.test.tsx       # test for HomePage
+      home-grid.test.tsx  # test for subcomponent
+```
+
+### ✅ Promotion Guidelines
+
+- Components/hooks start inside their page folder.
+- If reused across multiple pages, **promote** them to `/src/components` or `/src/hooks`.
+- Update imports accordingly.
+
+### 🚫 Anti-Pattern
+
+- Don’t define multiple large components inline inside the page file.
+- Don’t put page logic directly in `index.tsx`.
 
 ## 🧭 Routing Conventions (react-router-dom)
 
@@ -91,7 +133,7 @@ src/
 
 - Re-creating standard controls instead of using PrimeReact equivalents.
 - Mixing multiple CSS frameworks; keep to PrimeReact + PrimeFlex (and tiny overrides).
-- Uncontrolled inputs in complex forms—prefer `react-hook-form`.
+- Uncontrolled inputs in complex forms — prefer `react-hook-form`.
 
 ## 📦 Example Copilot “Scaffolds” It Should Produce
 

--- a/.github/instructions/react.instructions.md
+++ b/.github/instructions/react.instructions.md
@@ -55,4 +55,47 @@ src/
 - Use **loaders/actions** when appropriate for data fetching/mutations (or colocate TanStack Query inside routes).
 - Route files co-located by feature; **nest** where it improves organization.
 
-(... trimmed for brevity ...)
+## 🎨 UI & Styling (PrimeReact)
+
+- Import theme + core styles once in `main.tsx` or `styles/global.css`:
+  - `primereact/resources/themes/lara-light-blue/theme.css`
+  - `primereact/resources/primereact.min.css`
+  - `primeicons/primeicons.css`
+  - (Optional) **PrimeFlex** for layout utilities
+- Prefer component props and theme tokens over custom CSS; use small scoped overrides when needed.
+- Validation: add `p-invalid` class and `<small className="p-error">` helpers.
+
+## 🔌 Data & API
+
+- Create a typed `apiClient` (Fetch or Axios) with:
+  - Base URL, auth, and error normalization.
+  - Helpers for GET/POST/PUT/DELETE returning typed data.
+- For server state, use **TanStack Query**; include all inputs in `queryKey`.
+- Mutations: optimistic updates with rollback where safe; invalidate on success.
+
+## 🧪 Testing
+
+- Use React Testing Library; test behavior and accessibility (roles/labels).
+- For routes, wrap tests with `MemoryRouter` and render route elements.
+- Mock network (MSW suggested) and test loading/empty/error states.
+
+## ✅ Patterns to Prefer
+
+- **Lazy-loaded** route modules for code-splitting.
+- **Toast** for notifications; **Dialog** for modals; **ConfirmDialog** for confirms.
+- **DataTable** for tabular data (pagination/sort/filter as needed).
+- **react-hook-form + zod** for forms (`InputText`, `Dropdown`, `Calendar`, `Password`, `Checkbox`, etc.).
+- **PrimeIcons** via `icon="pi pi-..."` on PrimeReact components.
+
+## 🚫 Patterns to Avoid
+
+- Re-creating standard controls instead of using PrimeReact equivalents.
+- Mixing multiple CSS frameworks; keep to PrimeReact + PrimeFlex (and tiny overrides).
+- Uncontrolled inputs in complex forms—prefer `react-hook-form`.
+
+## 📦 Example Copilot “Scaffolds” It Should Produce
+
+- **Form with validation + PrimeReact controls** (with `p-invalid` and error text).
+- **Paginated DataTable** wired to TanStack Query with `queryKey` and `queryFn`.
+- **Route module** with `lazy` export and loader, plus suspense boundaries.
+- **Toast** usage via `Toast` ref and `toast.current?.show({ severity: 'success', ... })`.

--- a/.github/instructions/react.instructions.md
+++ b/.github/instructions/react.instructions.md
@@ -56,9 +56,10 @@ src/
 
 Inside `/src/pages/{pageName}`:
 
+- Capitalize the page and component names. It helps differentiate pages from HTML elements.
 - `index.tsx` → **entry point only**. Re-exports the main page component for routing. Must not contain UI logic.
 - `{pageName}.tsx` → main page component, top-level container.
-- `{pageName}-*.tsx` → supporting components (`home-grid.tsx`, `user-form.tsx`).
+- `{pageName}{componentName}.tsx` → supporting components (`HomeGrid.tsx`, `UserForm.tsx`).
 - `{pageName}.hooks.ts` → custom hooks scoped to the page.
 - `{pageName}.types.ts` → shared TS types/interfaces.
 - `{pageName}.test.tsx` → tests for the main page. Supporting components may also have their own `*.test.tsx`.
@@ -69,15 +70,15 @@ Inside `/src/pages/{pageName}`:
 ```
 src/
   pages/
-    home/
+    Home/
       index.tsx           # re-exports HomePage
-      home.tsx            # main page component
-      home-grid.tsx       # subcomponent
-      home-panel.tsx      # subcomponent
-      home.hooks.ts       # page-specific hooks
-      home.types.ts       # page-specific types
-      home.test.tsx       # test for HomePage
-      home-grid.test.tsx  # test for subcomponent
+      Home.tsx            # main page component
+      Home.test.tsx       # test for HomePage
+      Home.hooks.ts       # page-specific hooks
+      Home.types.ts       # page-specific types
+      HomeGrid.tsx        # subcomponent
+      HomeGrid.test.tsx   # test for subcomponent
+      HomePanel.tsx      # subcomponent
 ```
 
 ### ✅ Promotion Guidelines

--- a/apps/web/src/app/layouts/AppLayout.tsx
+++ b/apps/web/src/app/layouts/AppLayout.tsx
@@ -1,6 +1,7 @@
 import { Outlet } from 'react-router-dom';
 
 import { Sidebar } from '~/components/layout/Sidebar';
+import { DrawingToolbar } from '~/features/drawing/components/DrawingToolbar';
 import { MapView } from '~/features/map/components/MapView';
 
 export function AppLayout() {
@@ -13,6 +14,9 @@ export function AppLayout() {
       </aside>
       <main className="app-shell__map" aria-label="Map viewport">
         <MapView />
+        <div className="map-toolbar" aria-live="polite">
+          <DrawingToolbar />
+        </div>
       </main>
     </div>
   );

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -1,9 +1,5 @@
 import { ReactNode } from 'react';
-import { Panel } from 'primereact/panel';
-
-import { environment } from '~/config/environment';
 import { FeatureListPanel } from '~/features/feature/components/FeatureListPanel';
-import { DrawingToolbar } from '~/features/drawing/components/DrawingToolbar';
 
 type SidebarProps = {
   children?: ReactNode;
@@ -18,15 +14,8 @@ export function Sidebar({ children }: SidebarProps) {
           Browse map features, inspect their details, and visualize them on the map.
         </p>
       </header>
-      <DrawingToolbar />
       <FeatureListPanel />
       {children}
-      <Panel header="API configuration" className="sidebar__panel">
-        <p className="sidebar__text">
-          Base URL:&nbsp;
-          <code>{environment.apiBaseUrl}</code>
-        </p>
-      </Panel>
     </div>
   );
 }

--- a/apps/web/src/features/drawing/components/DrawingToolbar.tsx
+++ b/apps/web/src/features/drawing/components/DrawingToolbar.tsx
@@ -37,26 +37,6 @@ export function DrawingToolbar() {
   const isEditing = mode === 'editing';
   const isSelecting = mode === 'selecting';
 
-  const statusMessage = useMemo(() => {
-    if (isSaving) {
-      return 'Saving geometry…';
-    }
-
-    if (isSelecting) {
-      return 'Select a feature on the map to focus its details.';
-    }
-
-    if (isDrawing && intent) {
-      return `Drawing a ${intent} feature.`;
-    }
-
-    if (isEditing) {
-      return 'Editing geometry for the selected feature.';
-    }
-
-    return 'Choose an action to draw, edit, or select map features.';
-  }, [intent, isDrawing, isEditing, isSaving, isSelecting]);
-
   const hint = useMemo(() => {
     if (isDrawing && intent) {
       return DRAWING_HINTS[intent];
@@ -102,9 +82,8 @@ export function DrawingToolbar() {
   const shouldShowError = Boolean(error) && isDrawing;
 
   return (
-    <Panel header="Geometry tools" className="drawing-toolbar__panel">
+    <Panel className="drawing-toolbar__panel">
       <div className="drawing-toolbar" aria-live="polite">
-        <p className="drawing-toolbar__status">{statusMessage}</p>
         <div className="drawing-toolbar__actions">
           <Button
             label="Select"
@@ -126,9 +105,9 @@ export function DrawingToolbar() {
             />
           ))}
         </div>
-        {hint ? <p className="drawing-toolbar__hint">{hint}</p> : null}
         {isDrawing || isSelecting ? (
           <div className="drawing-toolbar__footer">
+            {hint ? <p className="drawing-toolbar__hint">{hint}</p> : null}
             <Button
               label={isSelecting ? 'Cancel selection' : 'Cancel drawing'}
               icon="pi pi-times"

--- a/apps/web/src/features/drawing/state.ts
+++ b/apps/web/src/features/drawing/state.ts
@@ -4,7 +4,7 @@ import type { Feature, FeatureGeometry, FeatureProperties } from '../feature/typ
 import type { EditableFeatureKind } from '../feature/types';
 import { cloneGeometry } from './utils';
 
-export type DrawingMode = 'idle' | 'drawing' | 'editing';
+export type DrawingMode = 'idle' | 'drawing' | 'editing' | 'selecting';
 export type DrawingIntent = EditableFeatureKind;
 
 interface EditingSession {
@@ -22,6 +22,7 @@ interface DrawingState {
   isSaving: boolean;
   error?: string;
   startDrawing: (intent: EditableFeatureKind) => void;
+  startSelecting: () => void;
   startEditing: (feature: Feature) => void;
   setEditingDraft: (geometry: FeatureGeometry) => void;
   markSaving: () => void;
@@ -42,6 +43,14 @@ export const useDrawingStore = create<DrawingState>((set) => ({
     set({
       mode: 'drawing',
       intent,
+      editing: undefined,
+      isSaving: false,
+      error: undefined,
+    }),
+  startSelecting: () =>
+    set({
+      mode: 'selecting',
+      intent: undefined,
       editing: undefined,
       isSaving: false,
       error: undefined,

--- a/apps/web/src/features/feature/api.ts
+++ b/apps/web/src/features/feature/api.ts
@@ -56,3 +56,7 @@ export async function updateFeatureTags(
 ): Promise<Feature> {
   return apiClient.patch<Feature>(`/features/${featureId}/tags`, { json: payload });
 }
+
+export async function deleteFeature(featureId: string): Promise<void> {
+  await apiClient.delete<void>(`/features/${featureId}`);
+}

--- a/apps/web/src/features/feature/components/FeatureListPanel.tsx
+++ b/apps/web/src/features/feature/components/FeatureListPanel.tsx
@@ -68,9 +68,9 @@ function countFeaturePoints(feature: Feature): number {
 
 function formatPointCount(count: number): string {
   if (count === 1) {
-    return '1 point';
+    return '1';
   }
-  return `${count} points`;
+  return `${count}`;
 }
 
 export function FeatureListPanel() {
@@ -148,8 +148,16 @@ export function FeatureListPanel() {
         </p>
       ) : (
         <div className="feature-list__scroll" role="region" aria-label="Loaded map features">
+          {/* Column headers */}
+          <div className="feature-list__header" aria-hidden="true">
+            <div className="feature-list__select feature-list__select--header">
+              <span className="feature-list__col-label">Type</span>
+              <span className="feature-list__col-label">Points</span>
+            </div>
+            <div />
+          </div>
           <ul className="feature-list">
-            {rows.map(({ feature, updatedAt, pointCount }) => {
+            {rows.map(({ feature, pointCount }) => {
               const isSelected = selectedFeatureId === feature.id;
               const rowClassName = isSelected
                 ? 'feature-list__row feature-list__row--active'
@@ -167,21 +175,14 @@ export function FeatureListPanel() {
                       disabled={isDeleting}
                     >
                       <span className="feature-list__field">
-                        <span className="feature-list__label">Type</span>
                         <span className="feature-list__value">{formatFeatureKind(feature.properties.kind)}</span>
                       </span>
                       <span className="feature-list__field">
-                        <span className="feature-list__label">Updated</span>
-                        <span className="feature-list__value">{updatedAt}</span>
-                      </span>
-                      <span className="feature-list__field">
-                        <span className="feature-list__label">Points</span>
                         <span className="feature-list__value">{formatPointCount(pointCount)}</span>
                       </span>
                     </button>
                     <Button
                       icon="pi pi-trash"
-                      label="Delete"
                       severity="danger"
                       text
                       className="feature-list__delete"

--- a/apps/web/src/features/feature/hooks.ts
+++ b/apps/web/src/features/feature/hooks.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
-import { createFeature, getFeature, updateFeature, updateFeatureTags } from './api';
+import { createFeature, deleteFeature, getFeature, updateFeature, updateFeatureTags } from './api';
 import { featureKeys, featureQueries } from './queries';
 import type { FeatureListParams, FeatureMutationPayload, UpdateFeatureTagsPayload } from './types';
 import type { ApiError } from '~/lib/apiClient';
@@ -120,6 +120,18 @@ export function useUpdateFeatureTagsMutation() {
     onSettled: (_result, _error, variables) => {
       queryClient.invalidateQueries({ queryKey: featureKeys.detail(variables.featureId) });
       queryClient.invalidateQueries({ queryKey: featureKeys.all });
+    },
+  });
+}
+
+export function useDeleteFeatureMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation<void, ApiError, string>({
+    mutationFn: (featureId) => deleteFeature(featureId),
+    onSuccess: (_result, featureId) => {
+      queryClient.invalidateQueries({ queryKey: featureKeys.list() });
+      queryClient.removeQueries({ queryKey: featureKeys.detail(featureId), exact: true });
     },
   });
 }

--- a/apps/web/src/styles/global.css
+++ b/apps/web/src/styles/global.css
@@ -41,6 +41,24 @@ body {
   overflow: hidden;
 }
 
+.map-toolbar {
+  position: absolute;
+  top: 1.5rem;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  padding: 0 1rem;
+  pointer-events: none;
+  z-index: 5;
+}
+
+.map-toolbar .drawing-toolbar__panel {
+  pointer-events: auto;
+  width: min(640px, 100%);
+}
+
 .sidebar {
   display: flex;
   flex-direction: column;
@@ -69,6 +87,20 @@ body {
 
 .sidebar__text {
   margin: 0;
+}
+
+.drawing-toolbar__panel {
+  border-radius: 0.75rem;
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.18);
+  overflow: hidden;
+}
+
+.drawing-toolbar__panel .p-panel-header {
+  font-weight: 600;
+}
+
+.drawing-toolbar__panel :where(.p-panel-header, .p-panel-content) {
+  border: none;
 }
 
 .drawing-toolbar {
@@ -157,37 +189,88 @@ body {
   margin: 0;
 }
 
-.feature-list__link {
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
+.feature-list__scroll {
+  max-height: min(420px, 50vh);
+  overflow-y: auto;
+  padding-right: 0.25rem;
+}
+
+.feature-list__row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  gap: 0.75rem;
   padding: 0.75rem;
   border: 1px solid var(--surface-border, #dfe3e8);
   border-radius: 0.75rem;
-  text-decoration: none;
-  color: inherit;
+  background-color: var(--surface-card, #ffffff);
   transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
 }
 
-.feature-list__link:hover,
-.feature-list__link:focus-visible {
+.feature-list__row:hover {
   border-color: #2563eb;
-  box-shadow: 0 0 0 1px rgba(37, 99, 235, 0.2);
-  outline: none;
 }
 
-.feature-list__link--active {
+.feature-list__row--active {
   border-color: #2563eb;
+  box-shadow: 0 0 0 1px rgba(37, 99, 235, 0.2);
   background-color: rgba(37, 99, 235, 0.08);
 }
 
-.feature-list__name {
-  font-weight: 600;
+.feature-list__select {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.75rem;
+  border: none;
+  background: none;
+  padding: 0;
+  margin: 0;
+  text-align: left;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
 }
 
-.feature-list__meta {
-  font-size: 0.85rem;
+.feature-list__select:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.35);
+  border-radius: 0.5rem;
+}
+
+.feature-list__select[disabled] {
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+.feature-list__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.feature-list__label {
+  font-size: 0.75rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
   color: var(--text-color-secondary, #64748b);
+}
+
+.feature-list__value {
+  font-weight: 600;
+  word-break: break-word;
+}
+
+.feature-list__delete {
+  justify-self: end;
+}
+
+.feature-list__error {
+  margin: 0 0 0.75rem;
+  padding: 0.75rem;
+  border-radius: 0.75rem;
+  background-color: rgba(220, 38, 38, 0.08);
+  color: #b91c1c;
+  font-size: 0.9rem;
 }
 
 .feature-detail {

--- a/apps/web/src/styles/global.css
+++ b/apps/web/src/styles/global.css
@@ -24,7 +24,7 @@ body {
 
 .app-shell {
   display: grid;
-  grid-template-columns: 320px 1fr;
+  grid-template-columns: 400px 1fr;
   height: 100%;
   max-height: 100vh;
 }
@@ -186,7 +186,7 @@ body {
   margin: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.3rem;
 }
 
 .feature-list__item {
@@ -203,10 +203,10 @@ body {
   display: grid;
   grid-template-columns: 1fr auto;
   align-items: center;
-  gap: 0.75rem;
-  padding: 0.75rem;
+  gap: 0.25rem;
+  padding: 0.25rem 0.5rem;
   border: 1px solid var(--surface-border, #dfe3e8);
-  border-radius: 0.75rem;
+  border-radius: 0.5rem;
   background-color: var(--surface-card, #ffffff);
   transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
 }
@@ -223,8 +223,8 @@ body {
 
 .feature-list__select {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(115px, 1fr));
+  gap: 0.5rem;
   border: none;
   background: none;
   padding: 0;
@@ -250,6 +250,7 @@ body {
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
+  min-width: 0;
 }
 
 .feature-list__label {
@@ -260,8 +261,11 @@ body {
 }
 
 .feature-list__value {
-  font-weight: 600;
+  font-weight: 400; /* was 600; row text now normal weight */
   word-break: break-word;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .feature-list__delete {
@@ -485,3 +489,58 @@ body {
     border-bottom: 1px solid var(--surface-border, #dfe3e8);
   }
 }
+
+/* Feature list layout tightening overrides */
+.feature-list__row {
+  /* Slightly more horizontal space inside rows */
+  padding: 0.25rem 0.5rem;
+}
+
+.feature-list__select {
+  /* Reduce column minimum so two columns fit in ~272px content width (320px - sidebar padding) */
+  grid-template-columns: repeat(auto-fit, minmax(115px, 1fr));
+  gap: 0.5rem; /* tighter gap */
+}
+
+.feature-list__field {
+  min-width: 0; /* allow flex/grid children to shrink */
+}
+
+.feature-list__value {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis; /* prevent wrapping that forces stacking */
+}
+
+/* Optional small-width fallback to single column if extremely narrow */
+@media (max-width: 340px) {
+  .feature-list__select {
+    grid-template-columns: 1fr; /* stack when too narrow */
+  }
+}
+
+.feature-list__header {
+  display: grid;
+  grid-template-columns: 1fr auto; /* match row layout (button + delete) */
+  align-items: center;
+  padding: 0 0.5rem 0.25rem; /* slight bottom separation */
+  margin: 0 0 0.25rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--text-color-secondary, #64748b);
+}
+
+.feature-list__select--header {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(115px, 1fr));
+  gap: 0.5rem;
+  pointer-events: none;
+}
+
+.feature-list__col-label {
+  font-weight: bolder;
+  font-size: larger;
+}
+
+/* Hide labels inside rows now; keep structure for accessibility (already removed label spans in TSX) */

--- a/apps/web/src/styles/global.css
+++ b/apps/web/src/styles/global.css
@@ -97,10 +97,12 @@ body {
 
 .drawing-toolbar__panel .p-panel-header {
   font-weight: 600;
+  padding: 0.5rem;
 }
 
 .drawing-toolbar__panel :where(.p-panel-header, .p-panel-content) {
   border: none;
+  padding: 0.5rem;
 }
 
 .drawing-toolbar {
@@ -123,6 +125,8 @@ body {
 
 .drawing-toolbar__hint {
   margin: 0;
+  margin-right: 1.5rem;
+  align-content: center;
   font-size: 0.85rem;
   color: var(--text-color-secondary, #64748b);
 }


### PR DESCRIPTION
## Summary
- move the geometry tools into a floating map toolbar with a new select mode and brighter highlight styling
- streamline the sidebar by removing the API config panel and rebuilding the feature list as a scrollable summary with delete actions
- add client support for deleting features and keep TanStack Query caches in sync

## Testing
- pnpm -C apps/web lint
- pnpm -C apps/web typecheck
- pnpm -C apps/web build

------
https://chatgpt.com/codex/tasks/task_e_68d4570c04c48326b43de870c548749a