### PR TITLE
Add lanelet drawing tool

### DIFF
--- a/apps/api/src/data/datasource.ts
+++ b/apps/api/src/data/datasource.ts
@@ -2,6 +2,17 @@ import 'reflect-metadata';
 import { DataSource } from 'typeorm';
 import { config } from '../config';
 
+// Determine if we are running the TypeScript sources directly (ts-node / ts-node-dev)
+const isTsRuntime = __filename.endsWith('.ts');
+
+const entityGlobs = isTsRuntime
+  ? ['src/data/entities/**/*.entity.ts']
+  : ['dist/data/entities/**/*.entity.{js,cjs}'];
+
+const migrationGlobs = isTsRuntime
+  ? ['src/data/migrations/**/*.{ts}']
+  : ['dist/data/migrations/**/*.{js,cjs}'];
+
 export const AppDataSource = new DataSource({
   type: 'postgres',
   host: config.db.host,
@@ -9,14 +20,9 @@ export const AppDataSource = new DataSource({
   username: config.db.user,
   password: config.db.password,
   database: config.db.database,
-  entities: [
-    'src/data/entities/*.entity.ts',
-    'dist/data/entities/*.entity.js',
-  ],
-  migrations: [
-    'src/data/migrations/*.ts',
-    'dist/data/migrations/*.js',
-  ],
+  // Wildcard entity discovery (TS in dev, compiled JS in prod)
+  entities: entityGlobs,
+  migrations: migrationGlobs,
   synchronize: false,
   migrationsTableName: 'migration',
   migrationsTransactionMode: 'each',

--- a/apps/api/src/data/entities/feature.entity.ts
+++ b/apps/api/src/data/entities/feature.entity.ts
@@ -7,7 +7,7 @@ import {
   UpdateDateColumn,
 } from 'typeorm';
 
-export type FeatureKind = 'point' | 'line' | 'polygon' | 'road';
+export type FeatureKind = 'point' | 'line' | 'polygon' | 'road' | 'lanelet';
 
 @Entity({ name: 'features' })
 export class FeatureEntity {

--- a/apps/api/src/data/migrations/1700000001000-AddLaneletKind.ts
+++ b/apps/api/src/data/migrations/1700000001000-AddLaneletKind.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddLaneletKind1700000001000 implements MigrationInterface {
+  name = 'AddLaneletKind1700000001000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE features DROP CONSTRAINT IF EXISTS features_kind_check`
+    );
+    await queryRunner.query(
+      `ALTER TABLE features ADD CONSTRAINT features_kind_check CHECK (kind IN ('point','line','polygon','road','lanelet'))`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE features DROP CONSTRAINT IF EXISTS features_kind_check`
+    );
+    await queryRunner.query(
+      `ALTER TABLE features ADD CONSTRAINT features_kind_check CHECK (kind IN ('point','line','polygon','road'))`
+    );
+  }
+}

--- a/apps/api/src/resources/feature/feature.service.ts
+++ b/apps/api/src/resources/feature/feature.service.ts
@@ -25,6 +25,7 @@ const GEOMETRY_BY_KIND: Record<FeatureKind, GeometryType[]> = {
   line: ['LineString', 'MultiLineString'],
   polygon: ['Polygon', 'MultiPolygon'],
   road: ['LineString', 'MultiLineString'],
+  lanelet: ['MultiLineString'],
 };
 const SUPPORTED_GEOMETRY_TYPES = new Set<GeometryType>(
   Object.values(GEOMETRY_BY_KIND).flat() as GeometryType[]

--- a/apps/api/src/routes.ts
+++ b/apps/api/src/routes.ts
@@ -103,7 +103,7 @@ const models: TsoaRoute.Models = {
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "FeatureKind": {
         "dataType": "refAlias",
-        "type": {"dataType":"union","subSchemas":[{"dataType":"enum","enums":["point"]},{"dataType":"enum","enums":["line"]},{"dataType":"enum","enums":["polygon"]},{"dataType":"enum","enums":["road"]}],"validators":{}},
+        "type": {"dataType":"union","subSchemas":[{"dataType":"enum","enums":["point"]},{"dataType":"enum","enums":["line"]},{"dataType":"enum","enums":["polygon"]},{"dataType":"enum","enums":["road"]},{"dataType":"enum","enums":["lanelet"]}],"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "Record_string.string_": {

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -6,8 +6,6 @@ async function start() {
   try {
     await AppDataSource.initialize();
     console.log('Database connected');
-    await AppDataSource.runMigrations();
-    console.log('Database migrations applied');
     app.listen(config.port, () => {
       console.log(`API server running on port ${config.port}`);
     });

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -6,6 +6,8 @@ async function start() {
   try {
     await AppDataSource.initialize();
     console.log('Database connected');
+    await AppDataSource.runMigrations();
+    console.log('Database migrations applied');
     app.listen(config.port, () => {
       console.log(`API server running on port ${config.port}`);
     });

--- a/apps/api/src/spec/openapi.json
+++ b/apps/api/src/spec/openapi.json
@@ -191,13 +191,13 @@
 			},
 			"FeatureKind": {
 				"type": "string",
-                                "enum": [
-                                        "point",
-                                        "line",
-                                        "polygon",
-                                        "road",
-                                        "lanelet"
-                                ]
+				"enum": [
+					"point",
+					"line",
+					"polygon",
+					"road",
+					"lanelet"
+				]
 			},
 			"Record_string.string_": {
 				"properties": {},

--- a/apps/api/src/spec/openapi.json
+++ b/apps/api/src/spec/openapi.json
@@ -191,12 +191,13 @@
 			},
 			"FeatureKind": {
 				"type": "string",
-				"enum": [
-					"point",
-					"line",
-					"polygon",
-					"road"
-				]
+                                "enum": [
+                                        "point",
+                                        "line",
+                                        "polygon",
+                                        "road",
+                                        "lanelet"
+                                ]
 			},
 			"Record_string.string_": {
 				"properties": {},

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,6 +11,8 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.32.1",
+    "@turf/helpers": "^5.1.5",
+    "@turf/line-offset": "^5.1.5",
     "maplibre-gl": "^3.5.2",
     "maplibre-gl-draw": "^1.6.9",
     "primeicons": "^7.0.0",

--- a/apps/web/src/features/drawing/components/DrawingToolbar.tsx
+++ b/apps/web/src/features/drawing/components/DrawingToolbar.tsx
@@ -4,8 +4,9 @@ import { useMemo } from 'react';
 
 import { useDrawingStore } from '../state';
 import type { DrawingIntent } from '../state';
+import { LANELET_OFFSET_STEP_METERS } from '../state';
 
-const DRAWING_HINTS: Record<DrawingIntent, string> = {
+const DRAWING_HINTS: Record<Exclude<DrawingIntent, 'lanelet'>, string> = {
   point: 'Click on the map to place the point.',
   line: 'Click to add vertices. Double-click to finish the line.',
   polygon: 'Click to add vertices. Double-click to close the polygon.',
@@ -15,19 +16,24 @@ const DRAWING_LABELS: Record<DrawingIntent, string> = {
   point: 'Draw point',
   line: 'Draw line',
   polygon: 'Draw polygon',
+  lanelet: 'Draw lanelet',
 };
 
 const DRAWING_ICONS: Record<DrawingIntent, string> = {
   point: 'pi pi-map-marker',
   line: 'pi pi-chart-line',
   polygon: 'pi pi-stop',
+  lanelet: 'pi pi-sliders-h',
 };
+
+const DRAWING_INTENTS: DrawingIntent[] = ['point', 'line', 'polygon', 'lanelet'];
 
 export function DrawingToolbar() {
   const mode = useDrawingStore((state) => state.mode);
   const intent = useDrawingStore((state) => state.intent);
   const isSaving = useDrawingStore((state) => state.isSaving);
   const error = useDrawingStore((state) => state.error);
+  const laneletOffset = useDrawingStore((state) => state.laneletOffset);
   const startDrawing = useDrawingStore((state) => state.startDrawing);
   const startSelecting = useDrawingStore((state) => state.startSelecting);
   const reset = useDrawingStore((state) => state.reset);
@@ -39,7 +45,12 @@ export function DrawingToolbar() {
 
   const hint = useMemo(() => {
     if (isDrawing && intent) {
-      return DRAWING_HINTS[intent];
+      if (intent === 'lanelet') {
+        const laneWidth = (laneletOffset * 2).toFixed(1);
+        return `Click to add centerline vertices. Double-click to finish. Use "=" to widen and "-" to narrow (${laneWidth} m total width, ${LANELET_OFFSET_STEP_METERS} m step).`;
+      }
+
+      return DRAWING_HINTS[intent as Exclude<DrawingIntent, 'lanelet'>];
     }
 
     if (isSelecting) {
@@ -47,7 +58,7 @@ export function DrawingToolbar() {
     }
 
     return undefined;
-  }, [intent, isDrawing, isSelecting]);
+  }, [intent, isDrawing, isSelecting, laneletOffset]);
 
   const handleStart = (nextIntent: DrawingIntent) => {
     if (isSaving) {
@@ -93,7 +104,7 @@ export function DrawingToolbar() {
             onClick={handleSelect}
             disabled={isSaving || isEditing}
           />
-          {(Object.keys(DRAWING_LABELS) as DrawingIntent[]).map((key) => (
+          {DRAWING_INTENTS.map((key) => (
             <Button
               key={key}
               label={DRAWING_LABELS[key]}

--- a/apps/web/src/features/drawing/components/DrawingToolbar.tsx
+++ b/apps/web/src/features/drawing/components/DrawingToolbar.tsx
@@ -47,7 +47,7 @@ export function DrawingToolbar() {
     if (isDrawing && intent) {
       if (intent === 'lanelet') {
         const laneWidth = (laneletOffset * 2).toFixed(1);
-        return `Click to add centerline vertices. Double-click to finish. Use "=" to widen and "-" to narrow (${laneWidth} m total width, ${LANELET_OFFSET_STEP_METERS} m step).`;
+        return `Click to add centerline vertices. Double-click to finish. Use "." to widen and "," to narrow (${laneWidth} m total width, ${LANELET_OFFSET_STEP_METERS} m step).`;
       }
 
       return DRAWING_HINTS[intent as Exclude<DrawingIntent, 'lanelet'>];

--- a/apps/web/src/features/drawing/state.ts
+++ b/apps/web/src/features/drawing/state.ts
@@ -4,6 +4,11 @@ import type { Feature, FeatureGeometry, FeatureProperties } from '../feature/typ
 import type { EditableFeatureKind } from '../feature/types';
 import { cloneGeometry } from './utils';
 
+export const DEFAULT_LANELET_OFFSET_METERS = 3.5;
+export const MIN_LANELET_OFFSET_METERS = 1.5;
+export const MAX_LANELET_OFFSET_METERS = 10;
+export const LANELET_OFFSET_STEP_METERS = 0.5;
+
 export type DrawingMode = 'idle' | 'drawing' | 'editing' | 'selecting';
 export type DrawingIntent = EditableFeatureKind;
 
@@ -21,6 +26,7 @@ interface DrawingState {
   editing?: EditingSession;
   isSaving: boolean;
   error?: string;
+  laneletOffset: number;
   startDrawing: (intent: EditableFeatureKind) => void;
   startSelecting: () => void;
   startEditing: (feature: Feature) => void;
@@ -30,6 +36,8 @@ interface DrawingState {
   reset: () => void;
   fail: (message: string) => void;
   clearError: () => void;
+  setLaneletOffset: (offset: number) => void;
+  adjustLaneletOffset: (delta: number) => void;
 }
 
 function cloneTags(tags: Record<string, string>): Record<string, string> {
@@ -39,14 +47,16 @@ function cloneTags(tags: Record<string, string>): Record<string, string> {
 export const useDrawingStore = create<DrawingState>((set) => ({
   mode: 'idle',
   isSaving: false,
+  laneletOffset: DEFAULT_LANELET_OFFSET_METERS,
   startDrawing: (intent) =>
-    set({
+    set((state) => ({
       mode: 'drawing',
       intent,
       editing: undefined,
       isSaving: false,
       error: undefined,
-    }),
+      laneletOffset: intent === 'lanelet' ? DEFAULT_LANELET_OFFSET_METERS : state.laneletOffset,
+    })),
   startSelecting: () =>
     set({
       mode: 'selecting',
@@ -98,7 +108,23 @@ export const useDrawingStore = create<DrawingState>((set) => ({
       editing: undefined,
       isSaving: false,
       error: undefined,
+      laneletOffset: DEFAULT_LANELET_OFFSET_METERS,
     }),
   fail: (message) => set({ isSaving: false, error: message }),
   clearError: () => set({ error: undefined }),
+  setLaneletOffset: (offset) =>
+    set({
+      laneletOffset: Math.min(Math.max(offset, MIN_LANELET_OFFSET_METERS), MAX_LANELET_OFFSET_METERS),
+    }),
+  adjustLaneletOffset: (delta) =>
+    set((state) => {
+      const next = Math.min(
+        Math.max(state.laneletOffset + delta, MIN_LANELET_OFFSET_METERS),
+        MAX_LANELET_OFFSET_METERS
+      );
+      if (next === state.laneletOffset) {
+        return {};
+      }
+      return { laneletOffset: next };
+    }),
 }));

--- a/apps/web/src/features/drawing/utils.ts
+++ b/apps/web/src/features/drawing/utils.ts
@@ -1,6 +1,10 @@
-import type { Geometry as GeoJsonGeometry } from 'geojson';
+import type { Feature as TurfFeature, LineString as TurfLineString } from '@turf/helpers';
+import { lineString as toTurfLineString } from '@turf/helpers';
+import lineOffset from '@turf/line-offset';
+import type { Geometry as GeoJsonGeometry, LineString, MultiLineString } from 'geojson';
 
 import type { FeatureGeometry } from '../feature/types';
+import { MIN_LANELET_OFFSET_METERS } from './state';
 
 function cloneCoordinates<T>(coordinates: T): T {
   if (coordinates === undefined) {
@@ -32,5 +36,78 @@ export function toGeoJsonGeometry(geometry: FeatureGeometry): GeoJsonGeometry {
   return {
     type: geometry.type,
     coordinates: cloneCoordinates(geometry.coordinates) as never,
+  };
+}
+
+export interface LaneletSegments {
+  left: LineString['coordinates'];
+  center: LineString['coordinates'];
+  right: LineString['coordinates'];
+}
+
+function ensureLineStringCoordinates(coordinates: unknown): LineString['coordinates'] | undefined {
+  if (!Array.isArray(coordinates)) {
+    return undefined;
+  }
+
+  if (coordinates.length < 2) {
+    return undefined;
+  }
+
+  const [first] = coordinates;
+  if (!Array.isArray(first)) {
+    return undefined;
+  }
+
+  return coordinates as LineString['coordinates'];
+}
+
+export function computeLaneletSegments(
+  centerCoordinates: LineString['coordinates'],
+  offsetMeters: number
+): LaneletSegments | undefined {
+  if (offsetMeters < MIN_LANELET_OFFSET_METERS) {
+    return undefined;
+  }
+
+  const centerLine: TurfFeature<TurfLineString> = toTurfLineString(centerCoordinates);
+  const left = lineOffset(centerLine, offsetMeters, { units: 'meters' });
+  const right = lineOffset(centerLine, -offsetMeters, { units: 'meters' });
+
+  if (!left.geometry || left.geometry.type !== 'LineString') {
+    return undefined;
+  }
+
+  if (!right.geometry || right.geometry.type !== 'LineString') {
+    return undefined;
+  }
+
+  const leftCoordinates = ensureLineStringCoordinates(left.geometry.coordinates);
+  const rightCoordinates = ensureLineStringCoordinates(right.geometry.coordinates);
+  if (!leftCoordinates || !rightCoordinates) {
+    return undefined;
+  }
+
+  return {
+    left: leftCoordinates,
+    center: centerCoordinates,
+    right: rightCoordinates,
+  };
+}
+
+export function createLaneletGeometry(
+  centerCoordinates: LineString['coordinates'],
+  offsetMeters: number
+): FeatureGeometry | undefined {
+  const segments = computeLaneletSegments(centerCoordinates, offsetMeters);
+  if (!segments) {
+    return undefined;
+  }
+
+  const coordinates: MultiLineString['coordinates'] = [segments.left, segments.center, segments.right];
+
+  return {
+    type: 'MultiLineString',
+    coordinates,
   };
 }

--- a/apps/web/src/features/feature/types.ts
+++ b/apps/web/src/features/feature/types.ts
@@ -12,7 +12,7 @@ export interface FeatureGeometry {
 }
 
 export interface FeatureProperties {
-  kind: 'point' | 'line' | 'polygon' | 'road';
+  kind: 'point' | 'line' | 'polygon' | 'road' | 'lanelet';
   tags: Record<string, string>;
   createdAt: string;
   updatedAt: string;
@@ -20,7 +20,7 @@ export interface FeatureProperties {
 
 export type FeatureKind = FeatureProperties['kind'];
 
-export type EditableFeatureKind = Extract<FeatureKind, 'point' | 'line' | 'polygon'>;
+export type EditableFeatureKind = Extract<FeatureKind, 'point' | 'line' | 'polygon' | 'lanelet'>;
 
 export interface Feature {
   type: 'Feature';

--- a/apps/web/src/features/map/components/MapView.tsx
+++ b/apps/web/src/features/map/components/MapView.tsx
@@ -845,13 +845,13 @@ export function MapView() {
         return;
       }
 
-      if (event.key === '=' || event.key === '+') {
+      if (event.key === '.' || event.key === '>') {
         event.preventDefault();
         useDrawingStore.getState().adjustLaneletOffset(LANELET_OFFSET_STEP_METERS);
         updateLaneletPreview();
       }
 
-      if (event.key === '-' || event.key === '_') {
+      if (event.key === ',' || event.key === '<') {
         event.preventDefault();
         useDrawingStore.getState().adjustLaneletOffset(-LANELET_OFFSET_STEP_METERS);
         updateLaneletPreview();

--- a/apps/web/src/features/map/components/MapView.tsx
+++ b/apps/web/src/features/map/components/MapView.tsx
@@ -19,16 +19,25 @@ import type {
   Feature as GeoJsonFeature,
   FeatureCollection as GeoJsonFeatureCollection,
   Geometry as GeoJsonGeometry,
+  LineString,
 } from 'geojson';
-import { useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import { ApiError } from '~/lib/apiClient';
 import { useCreateFeatureMutation, useFeatureList } from '~/features/feature/hooks';
 import type { FeatureCollection, FeatureProperties } from '~/features/feature/types';
-import { useDrawingStore } from '~/features/drawing/state';
+import {
+  LANELET_OFFSET_STEP_METERS,
+  useDrawingStore,
+} from '~/features/drawing/state';
 import type { DrawingIntent } from '~/features/drawing/state';
-import { fromGeoJsonGeometry, toGeoJsonGeometry } from '~/features/drawing/utils';
+import {
+  createLaneletGeometry,
+  fromGeoJsonGeometry,
+  toGeoJsonGeometry,
+  computeLaneletSegments,
+} from '~/features/drawing/utils';
 
 const MAP_STYLE: StyleSpecification = {
   version: 8,
@@ -63,6 +72,14 @@ const FEATURE_POINT_LAYER_ID = 'features-point';
 const SELECTED_FILL_LAYER_ID = 'selected-feature-fill';
 const SELECTED_LINE_LAYER_ID = 'selected-feature-line';
 const SELECTED_POINT_LAYER_ID = 'selected-feature-point';
+const LANELET_SEGMENTS_SOURCE_ID = 'lanelet-segments';
+const LANELET_SEGMENT_CENTER_LAYER_ID = 'lanelet-centerline';
+const LANELET_SEGMENT_OUTER_LAYER_ID = 'lanelet-outers';
+const SELECTED_LANELET_CENTER_LAYER_ID = 'selected-lanelet-centerline';
+const SELECTED_LANELET_OUTER_LAYER_ID = 'selected-lanelet-outers';
+const LANELET_PREVIEW_SOURCE_ID = 'lanelet-preview';
+const LANELET_PREVIEW_CENTER_LAYER_ID = 'lanelet-preview-centerline';
+const LANELET_PREVIEW_OUTER_LAYER_ID = 'lanelet-preview-outers';
 
 const BASE_POINT_COLOR = '#2563eb';
 const BASE_LINE_COLOR = '#2563eb';
@@ -70,8 +87,16 @@ const BASE_FILL_COLOR = '#38bdf8';
 const HIGHLIGHT_LINE_COLOR = '#facc15';
 const HIGHLIGHT_FILL_COLOR = '#fde68a';
 const HIGHLIGHT_POINT_COLOR = '#facc15';
+const LANELET_CENTER_COLOR = '#16a34a';
+const LANELET_OUTER_COLOR = '#15803d';
+const LANELET_PREVIEW_COLOR = '#0f172a';
+const LANELET_HIGHLIGHT_COLOR = '#facc15';
 
-const BASE_LINE_FILTER: LegacyFilterSpecification = ['in', '$type', 'LineString', 'Polygon'];
+const BASE_LINE_FILTER: LegacyFilterSpecification = [
+  'all',
+  ['in', '$type', 'LineString', 'Polygon'],
+  ['!=', 'kind', 'lanelet'],
+];
 const BASE_FILL_FILTER: LegacyFilterSpecification = ['==', '$type', 'Polygon'];
 const BASE_POINT_FILTER: LegacyFilterSpecification = ['==', '$type', 'Point'];
 
@@ -79,6 +104,28 @@ const EMPTY_GEOJSON: MapFeatureCollection = {
   type: 'FeatureCollection',
   features: [],
 };
+
+type LaneletRole = 'left' | 'center' | 'right';
+
+interface LaneletSegmentProperties extends FeatureProperties {
+  featureId: string;
+  laneletRole: LaneletRole;
+}
+
+type LaneletSegmentFeature = GeoJsonFeature<LineString, LaneletSegmentProperties>;
+type LaneletSegmentCollection = GeoJsonFeatureCollection<LineString, LaneletSegmentProperties>;
+
+const EMPTY_LANELET_SEGMENTS: LaneletSegmentCollection = {
+  type: 'FeatureCollection',
+  features: [],
+};
+
+const EMPTY_LANELET_PREVIEW: GeoJsonFeatureCollection<LineString, { laneletRole: LaneletRole }> = {
+  type: 'FeatureCollection',
+  features: [],
+};
+
+const LANELET_ROLES: LaneletRole[] = ['left', 'center', 'right'];
 
 type MapFeature = GeoJsonFeature<GeoJsonGeometry, FeatureProperties>;
 type MapFeatureCollection = GeoJsonFeatureCollection<GeoJsonGeometry, FeatureProperties>;
@@ -92,6 +139,8 @@ function getDrawModeForIntent(intent: DrawingIntent): DrawMode {
       return 'draw_line_string';
     case 'polygon':
       return 'draw_polygon';
+    case 'lanelet':
+      return 'draw_line_string';
     default:
       return 'draw_point';
   }
@@ -128,6 +177,51 @@ function toGeoJson(collection?: FeatureCollection): MapFeatureCollection {
       properties: feature.properties,
     })),
     bbox: toGeoJsonBbox(collection.bbox),
+  };
+}
+
+function toLaneletSegments(collection: MapFeatureCollection): LaneletSegmentCollection {
+  const features: LaneletSegmentFeature[] = [];
+
+  collection.features.forEach((feature) => {
+    if (feature.properties.kind !== 'lanelet') {
+      return;
+    }
+
+    if (feature.geometry.type !== 'MultiLineString') {
+      return;
+    }
+
+    const coordinates = (
+      feature.geometry as GeoJsonGeometry & { coordinates: LineString['coordinates'][] }
+    ).coordinates;
+    coordinates.forEach((segmentCoordinates, index) => {
+      if (!Array.isArray(segmentCoordinates) || segmentCoordinates.length === 0) {
+        return;
+      }
+
+      const role = LANELET_ROLES[index] ?? 'left';
+      const lineCoordinates = segmentCoordinates as LineString['coordinates'];
+
+      features.push({
+        type: 'Feature',
+        id: `${String(feature.id)}::${role}`,
+        properties: {
+          ...feature.properties,
+          featureId: String(feature.id),
+          laneletRole: role,
+        },
+        geometry: {
+          type: 'LineString',
+          coordinates: lineCoordinates,
+        },
+      });
+    });
+  });
+
+  return {
+    type: 'FeatureCollection',
+    features,
   };
 }
 
@@ -206,6 +300,27 @@ function updateHighlightFilters(map: Map, featureId: string | undefined) {
       map.setFilter(layerId, filter);
     }
   });
+
+  const laneletIdFilter: LegacyFilterSpecification = featureId
+    ? ['in', '$id', `${featureId}::left`, `${featureId}::center`, `${featureId}::right`]
+    : ['==', '$id', '__none__'];
+
+  const laneletHighlightFilters: Array<[string, LegacyFilterSpecification]> = [
+    [
+      SELECTED_LANELET_CENTER_LAYER_ID,
+      ['all', ['==', 'laneletRole', 'center'], laneletIdFilter] as LegacyFilterSpecification,
+    ],
+    [
+      SELECTED_LANELET_OUTER_LAYER_ID,
+      ['all', ['!=', 'laneletRole', 'center'], laneletIdFilter] as LegacyFilterSpecification,
+    ],
+  ];
+
+  laneletHighlightFilters.forEach(([layerId, filter]) => {
+    if (map.getLayer(layerId)) {
+      map.setFilter(layerId, filter);
+    }
+  });
 }
 
 export function MapView() {
@@ -230,15 +345,92 @@ export function MapView() {
   const drawingMode = useDrawingStore((state) => state.mode);
   const drawingIntent = useDrawingStore((state) => state.intent);
   const editingFeatureId = useDrawingStore((state) => state.editing?.featureId);
+  const laneletOffset = useDrawingStore((state) => state.laneletOffset);
 
   const { featureId } = useParams<{ featureId: string }>();
   const { data: collection } = useFeatureList();
 
   const geoJsonData = useMemo(() => toGeoJson(collection), [collection]);
+  const laneletSegments = useMemo(() => toLaneletSegments(geoJsonData), [geoJsonData]);
   const selectedFeature = useMemo(
     () => geoJsonData.features.find((feature: MapFeature) => feature.id === featureId),
     [geoJsonData, featureId]
   );
+
+  const updateLaneletPreview = useCallback(() => {
+    const map = mapRef.current;
+    const draw = drawRef.current;
+    if (!map || !draw) {
+      return;
+    }
+
+    const source = map.getSource(LANELET_PREVIEW_SOURCE_ID) as GeoJSONSource | undefined;
+    if (!source) {
+      return;
+    }
+
+    const state = useDrawingStore.getState();
+    if (state.mode !== 'drawing' || state.intent !== 'lanelet') {
+      source.setData(EMPTY_LANELET_PREVIEW);
+      return;
+    }
+
+    const all = draw.getAll();
+    const [draft] = all.features as DrawFeature[];
+    if (!draft || !draft.geometry || draft.geometry.type !== 'LineString') {
+      source.setData(EMPTY_LANELET_PREVIEW);
+      return;
+    }
+
+    const coordinates = (
+      draft.geometry as GeoJsonGeometry & { coordinates: LineString['coordinates'] }
+    ).coordinates;
+    if (!Array.isArray(coordinates) || coordinates.length < 2) {
+      source.setData(EMPTY_LANELET_PREVIEW);
+      return;
+    }
+
+    const segments = computeLaneletSegments(coordinates, state.laneletOffset);
+    if (!segments) {
+      source.setData(EMPTY_LANELET_PREVIEW);
+      return;
+    }
+
+    const previewFeatures: GeoJsonFeature<LineString, { laneletRole: LaneletRole }>[] = [
+      {
+        type: 'Feature',
+        id: 'preview-left',
+        properties: { laneletRole: 'left' },
+        geometry: {
+          type: 'LineString',
+          coordinates: segments.left,
+        },
+      },
+      {
+        type: 'Feature',
+        id: 'preview-center',
+        properties: { laneletRole: 'center' },
+        geometry: {
+          type: 'LineString',
+          coordinates: segments.center,
+        },
+      },
+      {
+        type: 'Feature',
+        id: 'preview-right',
+        properties: { laneletRole: 'right' },
+        geometry: {
+          type: 'LineString',
+          coordinates: segments.right,
+        },
+      },
+    ];
+
+    source.setData({
+      type: 'FeatureCollection',
+      features: previewFeatures,
+    });
+  }, []);
 
   useEffect(() => {
     if (!containerRef.current || mapRef.current) {
@@ -262,6 +454,7 @@ export function MapView() {
       const state = useDrawingStore.getState();
       if (state.mode === 'drawing' && state.intent) {
         changeDrawMode(draw, getDrawModeForIntent(state.intent));
+        updateLaneletPreview();
       }
     };
 
@@ -276,9 +469,23 @@ export function MapView() {
         return;
       }
 
-      const geometry = fromGeoJsonGeometry(created.geometry as GeoJsonGeometry);
+      let geometry = fromGeoJsonGeometry(created.geometry as GeoJsonGeometry);
+
+      if (state.intent === 'lanelet') {
+        const laneletCoordinates = (
+          created.geometry as GeoJsonGeometry & { coordinates: LineString['coordinates'] }
+        ).coordinates;
+        const laneletGeometry = createLaneletGeometry(laneletCoordinates, state.laneletOffset);
+        if (!laneletGeometry) {
+          useDrawingStore.getState().fail('Unable to generate lanelet geometry. Try drawing a longer centerline.');
+          draw.deleteAll();
+          return;
+        }
+        geometry = laneletGeometry;
+      }
       state.markSaving();
       draw.deleteAll();
+      updateLaneletPreview();
 
       createFeatureMutateRef.current(
         {
@@ -334,6 +541,7 @@ export function MapView() {
       if (state.mode === 'drawing' && state.intent && !state.isSaving && event.mode === 'simple_select') {
         changeDrawMode(draw, getDrawModeForIntent(state.intent));
       }
+      updateLaneletPreview();
     };
 
     const handleFeatureClick = (event: MapLayerMouseEvent) => {
@@ -342,13 +550,15 @@ export function MapView() {
         return;
       }
 
-      const features = event.features as MapFeature[] | undefined;
+      const features = event.features as (MapFeature | LaneletSegmentFeature)[] | undefined;
       if (!features || features.length === 0) {
         return;
       }
 
       const [clicked] = features;
-      const featureId = clicked?.id;
+
+      const properties = clicked?.properties as Partial<LaneletSegmentProperties> | undefined;
+      const featureId = properties?.featureId ?? (clicked?.id as string | number | undefined);
       if (featureId === undefined || featureId === null) {
         return;
       }
@@ -366,9 +576,12 @@ export function MapView() {
     map.on('draw.update', handleDrawUpdate);
     map.on('draw.selectionchange', handleSelectionChange);
     map.on('draw.modechange', handleModeChange);
+    map.on('draw.render', updateLaneletPreview);
     map.on('click', FEATURE_FILL_LAYER_ID, handleFeatureClick);
     map.on('click', FEATURE_LINE_LAYER_ID, handleFeatureClick);
     map.on('click', FEATURE_POINT_LAYER_ID, handleFeatureClick);
+    map.on('click', LANELET_SEGMENT_CENTER_LAYER_ID, handleFeatureClick);
+    map.on('click', LANELET_SEGMENT_OUTER_LAYER_ID, handleFeatureClick);
 
     map.on('load', () => {
       if (!map.getSource(FEATURE_SOURCE_ID)) {
@@ -413,6 +626,36 @@ export function MapView() {
         filter: BASE_POINT_FILTER,
       });
 
+      if (!map.getSource(LANELET_SEGMENTS_SOURCE_ID)) {
+        map.addSource(LANELET_SEGMENTS_SOURCE_ID, {
+          type: 'geojson',
+          data: EMPTY_LANELET_SEGMENTS,
+        });
+      }
+
+      map.addLayer({
+        id: LANELET_SEGMENT_OUTER_LAYER_ID,
+        type: 'line',
+        source: LANELET_SEGMENTS_SOURCE_ID,
+        paint: {
+          'line-color': LANELET_OUTER_COLOR,
+          'line-width': 3.5,
+        },
+        filter: ['all', ['!=', 'laneletRole', 'center']] as LegacyFilterSpecification,
+      });
+
+      map.addLayer({
+        id: LANELET_SEGMENT_CENTER_LAYER_ID,
+        type: 'line',
+        source: LANELET_SEGMENTS_SOURCE_ID,
+        paint: {
+          'line-color': LANELET_CENTER_COLOR,
+          'line-width': 2.5,
+          'line-dasharray': [0.4, 1.1],
+        },
+        filter: ['all', ['==', 'laneletRole', 'center']] as LegacyFilterSpecification,
+      });
+
       map.addLayer({
         id: SELECTED_FILL_LAYER_ID,
         type: 'fill',
@@ -452,6 +695,63 @@ export function MapView() {
         filter: ['all', BASE_POINT_FILTER, ['==', '$id', '__none__']] as LegacyFilterSpecification,
       });
 
+      map.addLayer({
+        id: SELECTED_LANELET_OUTER_LAYER_ID,
+        type: 'line',
+        source: LANELET_SEGMENTS_SOURCE_ID,
+        paint: {
+          'line-color': LANELET_HIGHLIGHT_COLOR,
+          'line-width': 6,
+          'line-opacity': 0.85,
+        },
+        filter: ['all', ['!=', 'laneletRole', 'center'], ['==', '$id', '__none__']] as LegacyFilterSpecification,
+      });
+
+      map.addLayer({
+        id: SELECTED_LANELET_CENTER_LAYER_ID,
+        type: 'line',
+        source: LANELET_SEGMENTS_SOURCE_ID,
+        paint: {
+          'line-color': LANELET_HIGHLIGHT_COLOR,
+          'line-width': 4.5,
+          'line-dasharray': [0.2, 0.4],
+          'line-opacity': 0.9,
+        },
+        filter: ['all', ['==', 'laneletRole', 'center'], ['==', '$id', '__none__']] as LegacyFilterSpecification,
+      });
+
+      if (!map.getSource(LANELET_PREVIEW_SOURCE_ID)) {
+        map.addSource(LANELET_PREVIEW_SOURCE_ID, {
+          type: 'geojson',
+          data: EMPTY_LANELET_PREVIEW,
+        });
+      }
+
+      map.addLayer({
+        id: LANELET_PREVIEW_OUTER_LAYER_ID,
+        type: 'line',
+        source: LANELET_PREVIEW_SOURCE_ID,
+        paint: {
+          'line-color': LANELET_PREVIEW_COLOR,
+          'line-width': 3,
+          'line-opacity': 0.5,
+        },
+        filter: ['all', ['!=', 'laneletRole', 'center']] as LegacyFilterSpecification,
+      });
+
+      map.addLayer({
+        id: LANELET_PREVIEW_CENTER_LAYER_ID,
+        type: 'line',
+        source: LANELET_PREVIEW_SOURCE_ID,
+        paint: {
+          'line-color': LANELET_PREVIEW_COLOR,
+          'line-width': 2,
+          'line-dasharray': [0.2, 0.6],
+          'line-opacity': 0.6,
+        },
+        filter: ['all', ['==', 'laneletRole', 'center']] as LegacyFilterSpecification,
+      });
+
       sourceReadyRef.current = true;
     });
 
@@ -463,9 +763,12 @@ export function MapView() {
       map.off('draw.update', handleDrawUpdate);
       map.off('draw.selectionchange', handleSelectionChange);
       map.off('draw.modechange', handleModeChange);
+      map.off('draw.render', updateLaneletPreview);
       map.off('click', FEATURE_FILL_LAYER_ID, handleFeatureClick);
       map.off('click', FEATURE_LINE_LAYER_ID, handleFeatureClick);
       map.off('click', FEATURE_POINT_LAYER_ID, handleFeatureClick);
+      map.off('click', LANELET_SEGMENT_CENTER_LAYER_ID, handleFeatureClick);
+      map.off('click', LANELET_SEGMENT_OUTER_LAYER_ID, handleFeatureClick);
 
       sourceReadyRef.current = false;
       hasFitToAllRef.current = false;
@@ -480,7 +783,7 @@ export function MapView() {
       mapRef.current = null;
       map.remove();
     };
-  }, []);
+  }, [updateLaneletPreview]);
 
   useEffect(() => {
     const map = mapRef.current;
@@ -532,6 +835,36 @@ export function MapView() {
   }, [drawingMode]);
 
   useEffect(() => {
+    updateLaneletPreview();
+  }, [drawingMode, drawingIntent, laneletOffset, updateLaneletPreview]);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const state = useDrawingStore.getState();
+      if (state.mode !== 'drawing' || state.intent !== 'lanelet') {
+        return;
+      }
+
+      if (event.key === '=' || event.key === '+') {
+        event.preventDefault();
+        useDrawingStore.getState().adjustLaneletOffset(LANELET_OFFSET_STEP_METERS);
+        updateLaneletPreview();
+      }
+
+      if (event.key === '-' || event.key === '_') {
+        event.preventDefault();
+        useDrawingStore.getState().adjustLaneletOffset(-LANELET_OFFSET_STEP_METERS);
+        updateLaneletPreview();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [updateLaneletPreview]);
+
+  useEffect(() => {
     const map = mapRef.current;
     if (!map) {
       return;
@@ -565,6 +898,20 @@ export function MapView() {
       }
     }
   }, [geoJsonData, featureId]);
+
+  useEffect(() => {
+    if (!mapRef.current || !sourceReadyRef.current) {
+      return;
+    }
+
+    const map = mapRef.current;
+    const source = map.getSource(LANELET_SEGMENTS_SOURCE_ID) as GeoJSONSource | undefined;
+    if (!source) {
+      return;
+    }
+
+    source.setData(laneletSegments);
+  }, [laneletSegments]);
 
   useEffect(() => {
     if (!mapRef.current || !sourceReadyRef.current) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,7 +64,7 @@ importers:
         version: 6.6.0
       typeorm:
         specifier: ^0.3.20
-        version: 0.3.26(pg@8.16.3)(reflect-metadata@0.1.14)(ts-node@10.9.2(@types/node@20.19.14)(typescript@5.3.3))
+        version: 0.3.26(pg@8.16.3)(reflect-metadata@0.1.14)(ts-node@10.9.2(@types/node@20.19.14)(typescript@5.9.2))
       zod:
         specifier: ^3.22.4
         version: 3.25.76
@@ -92,10 +92,10 @@ importers:
         version: 4.1.8
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.2(@types/node@20.19.14)(typescript@5.3.3)
+        version: 10.9.2(@types/node@20.19.14)(typescript@5.9.2)
       ts-node-dev:
         specifier: ^2.0.0
-        version: 2.0.0(@types/node@20.19.14)(typescript@5.3.3)
+        version: 2.0.0(@types/node@20.19.14)(typescript@5.9.2)
       typeorm-ts-node-commonjs:
         specifier: ^0.3.20
         version: 0.3.20
@@ -105,6 +105,12 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.32.1
         version: 5.89.0(react@18.3.1)
+      '@turf/helpers':
+        specifier: ^5.1.5
+        version: 5.1.5
+      '@turf/line-offset':
+        specifier: ^5.1.5
+        version: 5.1.5
       maplibre-gl:
         specifier: ^3.5.2
         version: 3.6.2
@@ -5704,7 +5710,7 @@ snapshots:
   geojson-rbush@2.1.0:
     dependencies:
       '@turf/helpers': 5.1.5
-      '@turf/meta': 5.1.6
+      '@turf/meta': 6.5.0
       rbush: 4.0.1
 
   geojson-validation@1.0.2: {}
@@ -6897,7 +6903,7 @@ snapshots:
 
   ts-deepmerge@7.0.3: {}
 
-  ts-node-dev@2.0.0(@types/node@20.19.14)(typescript@5.3.3):
+  ts-node-dev@2.0.0(@types/node@20.19.14)(typescript@5.9.2):
     dependencies:
       chokidar: 3.6.0
       dynamic-dedupe: 0.3.0
@@ -6907,15 +6913,15 @@ snapshots:
       rimraf: 2.7.1
       source-map-support: 0.5.21
       tree-kill: 1.2.2
-      ts-node: 10.9.2(@types/node@20.19.14)(typescript@5.3.3)
+      ts-node: 10.9.2(@types/node@20.19.14)(typescript@5.9.2)
       tsconfig: 7.0.0
-      typescript: 5.3.3
+      typescript: 5.9.2
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
       - '@types/node'
 
-  ts-node@10.9.2(@types/node@20.19.14)(typescript@5.3.3):
+  ts-node@10.9.2(@types/node@20.19.14)(typescript@5.9.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
@@ -6929,7 +6935,7 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 5.3.3
+      typescript: 5.9.2
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
@@ -7008,7 +7014,7 @@ snapshots:
 
   typeorm-ts-node-commonjs@0.3.20: {}
 
-  typeorm@0.3.26(pg@8.16.3)(reflect-metadata@0.1.14)(ts-node@10.9.2(@types/node@20.19.14)(typescript@5.3.3)):
+  typeorm@0.3.26(pg@8.16.3)(reflect-metadata@0.1.14)(ts-node@10.9.2(@types/node@20.19.14)(typescript@5.9.2)):
     dependencies:
       '@sqltools/formatter': 1.2.5
       ansis: 3.17.0
@@ -7027,7 +7033,7 @@ snapshots:
       yargs: 17.7.2
     optionalDependencies:
       pg: 8.16.3
-      ts-node: 10.9.2(@types/node@20.19.14)(typescript@5.3.3)
+      ts-node: 10.9.2(@types/node@20.19.14)(typescript@5.9.2)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color


### PR DESCRIPTION
## Context
- Implement Phase 9 of the roadmap by introducing a dedicated lanelet drawing workflow so editors can author multi-line lane geometries.

## Solution
- Extend the shared drawing store with configurable lanelet width controls and expose the new lanelet tool in the floating toolbar with contextual guidance.
- Rework the map view to render lanelet center/outer lines with custom styling, preview geometry while drawing with dynamic width adjustments, and update highlighting/selection logic accordingly.
- Allow the API to accept the new `lanelet` feature kind, including a migration updating the database constraint and OpenAPI schema so clients stay in sync.

## Verification
- `pnpm -C apps/web lint`
- `pnpm -C apps/web typecheck`
- `pnpm -C apps/api lint`
- `pnpm -C apps/api typecheck`

## Impact
- Adds a new database migration to update the feature kind constraint.


------
https://chatgpt.com/codex/tasks/task_e_68edba016ecc8326b375d67a77bd2a9f